### PR TITLE
US97555 Add future/ended/inactive support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.13.0",
     "d2l-icons": "BrightspaceUI/icons#^5.0.1",
+    "d2l-localize-behavior": "BrightspaceUI/localize-behavior#^1.1.2",
     "polymer": "1 - 2",
     "siren-parser-import": "Brightspace/siren-parser-import#^7.0.0"
   },

--- a/components/d2l-organization-info/d2l-organization-info.html
+++ b/components/d2l-organization-info/d2l-organization-info.html
@@ -39,10 +39,9 @@
 				text-transform: uppercase;
 			}
 
-			.flex {
+			.flex:not([hidden]) {
 				display: flex;
 				flex-direction: column;
-				align-items: middle;
 				margin-top: 0.6rem;
 			}
 		</style>
@@ -54,9 +53,9 @@
 			<span hidden$="[[!_showSemesterName]]">[[_semesterName]]</span>
 		</div>
 		<div class="small-text flex" hidden$="[[!_hasStatusText]]">
-			<span hidden$="[[!_isEnded]]">[[_statusTextEnded]]</span>
-			<span hidden$="[[!_isFuture]]">[[_statusTextFuture]]</span>
-			<span hidden$="[[!_isInactive]]">[[_statusTextInactive]]</span>
+			<span hidden$="[[!_statusTextEnded]]">[[_statusTextEnded]]</span>
+			<span hidden$="[[!_statusTextFuture]]">[[_statusTextFuture]]</span>
+			<span hidden$="[[!_statusTextInactive]]">[[_statusTextInactive]]</span>
 		</div>
 	</template>
 
@@ -71,19 +70,7 @@
 				_hasStatusText: {
 					type: Boolean,
 					value: false,
-					computed: '_computeHasStatusText(_isInactive, _isEnded, _isFuture)'
-				},
-				_isInactive: {
-					type: Boolean,
-					value: false
-				},
-				_isEnded: {
-					type: Boolean,
-					value: false
-				},
-				_isFuture: {
-					type: Boolean,
-					value: false
+					computed: '_computeHasStatusText(_statusTextEnded, _statusTextFuture, _statusTextInactive)'
 				},
 				_organization: Object,
 				_organizationCode: String,
@@ -118,8 +105,8 @@
 				'_fetchSemester(_organization, _showSemesterName)'
 			],
 
-			_computeHasStatusText: function(isInactive, isEnded, isFuture) {
-				return isInactive || isEnded || isFuture;
+			_computeHasStatusText: function(statusTextEnded, statusTextFuture, statusTextInactive) {
+				return statusTextEnded || statusTextFuture || statusTextInactive;
 			},
 
 			_computeShowSeparator: function(showOrganizationCode, showSemester, organizationCode, semesterName) {
@@ -134,6 +121,10 @@
 			_fetchOrganization: function(organizationHref) {
 				return this._fetchSirenEntity(organizationHref)
 					.then(function(organizationEntity) {
+						this._statusTextEnded = null;
+						this._statusTextFuture = null;
+						this._statusTextInactive = null;
+
 						if (!organizationEntity) {
 							return;
 						}
@@ -146,8 +137,9 @@
 						this._organizationName = organizationEntity.properties.name;
 						this._organizationCode = organizationEntity.properties.code;
 
-						this._isInactive = !organizationEntity.properties.isActive;
-						this._statusTextInactive = this.localize('brackets', 'content', this.localize('inactive'));
+						if (!organizationEntity.properties.isActive) {
+							this._statusTextInactive = this.localize('brackets', 'content', this.localize('inactive'));
+						}
 
 						var nowDate = Date.now();
 						var endDate = Date.parse(organizationEntity.properties.endDate);
@@ -156,16 +148,9 @@
 						if (endDate < nowDate) {
 							endDate = new Date(endDate);
 							this._statusTextEnded = this.localize('courseClosedOn', 'dateTime', this.formatDate(endDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(endDate));
-							this._isEnded = true;
-							this._isFuture = false;
 						} else if (startDate > nowDate) {
 							startDate = new Date(startDate);
 							this._statusTextFuture = this.localize('courseOpensOn', 'dateTime', this.formatDate(startDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(startDate));
-							this._isEnded = false;
-							this._isFuture = true;
-						} else {
-							this._isEnded = false;
-							this._isFuture = false;
 						}
 					}.bind(this));
 			},

--- a/components/d2l-organization-info/d2l-organization-info.html
+++ b/components/d2l-organization-info/d2l-organization-info.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../../d2l-icons/tier1-icons.html">
 <link rel="import" href="../../../siren-parser-import/siren-parser.html">
+<link rel="import" href="localize-behavior.html">
 
 <dom-module id="d2l-organization-info">
 	<template strip-whitespace>
@@ -15,6 +16,7 @@
 				display: flex;
 				flex-direction: column;
 				width: 100%;
+				text-align: center;
 			}
 
 			d2l-icon {
@@ -36,6 +38,13 @@
 			.uppercase {
 				text-transform: uppercase;
 			}
+
+			.flex {
+				display: flex;
+				flex-direction: column;
+				align-items: middle;
+				margin-top: 0.6rem;
+			}
 		</style>
 
 		<span>[[_organizationName]]</span>
@@ -43,6 +52,11 @@
 			<span hidden$="[[!_showOrganizationCode]]" class="uppercase">[[_organizationCode]]</span>
 			<d2l-icon hidden$="[[!_showSeparator]]" icon="d2l-tier1:bullet"></d2l-icon>
 			<span hidden$="[[!_showSemesterName]]">[[_semesterName]]</span>
+		</div>
+		<div class="small-text flex" hidden$="[[!_hasStatusText]]">
+			<span hidden$="[[!_isEnded]]">[[_statusTextEnded]]</span>
+			<span hidden$="[[!_isFuture]]">[[_statusTextFuture]]</span>
+			<span hidden$="[[!_isInactive]]">[[_statusTextInactive]]</span>
 		</div>
 	</template>
 
@@ -54,6 +68,23 @@
 				href: String,
 				presentationHref: String,
 
+				_hasStatusText: {
+					type: Boolean,
+					value: false,
+					computed: '_computeHasStatusText(_isInactive, _isEnded, _isFuture)'
+				},
+				_isInactive: {
+					type: Boolean,
+					value: false
+				},
+				_isEnded: {
+					type: Boolean,
+					value: false
+				},
+				_isFuture: {
+					type: Boolean,
+					value: false
+				},
 				_organization: Object,
 				_organizationCode: String,
 				_organizationName: String,
@@ -70,11 +101,15 @@
 					type: Boolean,
 					value: false,
 					computed: '_computeShowSeparator(_showOrganizationCode, _showSemesterName, _organizationCode, _semesterName)'
-				}
+				},
+				_statusTextEnded: String,
+				_statusTextFuture: String,
+				_statusTextInactive: String
 			},
 
 			behaviors: [
-				window.D2L.Hypermedia.HMConstantsBehavior
+				window.D2L.Hypermedia.HMConstantsBehavior,
+				D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior
 			],
 
 			observers: [
@@ -82,6 +117,10 @@
 				'_fetchPresentation(presentationHref)',
 				'_fetchSemester(_organization, _showSemesterName)'
 			],
+
+			_computeHasStatusText: function(isInactive, isEnded, isFuture) {
+				return isInactive || isEnded || isFuture;
+			},
 
 			_computeShowSeparator: function(showOrganizationCode, showSemester, organizationCode, semesterName) {
 				return showSemester
@@ -95,13 +134,39 @@
 			_fetchOrganization: function(organizationHref) {
 				return this._fetchSirenEntity(organizationHref)
 					.then(function(organizationEntity) {
+						if (!organizationEntity) {
+							return;
+						}
 						this._organization = organizationEntity;
-						this._organizationName = organizationEntity
-							&& organizationEntity.properties
-							&& organizationEntity.properties.name;
-						this._organizationCode = organizationEntity
-							&& organizationEntity.properties
-							&& organizationEntity.properties.code;
+
+						if (!organizationEntity.properties) {
+							return;
+						}
+
+						this._organizationName = organizationEntity.properties.name;
+						this._organizationCode = organizationEntity.properties.code;
+
+						this._isInactive = !organizationEntity.properties.isActive;
+						this._statusTextInactive = this.localize('brackets', 'content', this.localize('inactive'));
+
+						var nowDate = Date.now();
+						var endDate = Date.parse(organizationEntity.properties.endDate);
+						var startDate = Date.parse(organizationEntity.properties.startDate);
+
+						if (endDate < nowDate) {
+							endDate = new Date(endDate);
+							this._statusTextEnded = this.localize('courseClosedOn', 'dateTime', this.formatDate(endDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(endDate));
+							this._isEnded = true;
+							this._isFuture = false;
+						} else if (startDate > nowDate) {
+							startDate = new Date(startDate);
+							this._statusTextFuture = this.localize('courseOpensOn', 'dateTime', this.formatDate(startDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(startDate));
+							this._isEnded = false;
+							this._isFuture = true;
+						} else {
+							this._isEnded = false;
+							this._isFuture = false;
+						}
 					}.bind(this));
 			},
 

--- a/components/d2l-organization-info/localize-behavior.html
+++ b/components/d2l-organization-info/localize-behavior.html
@@ -1,0 +1,126 @@
+<link rel="import" href="../../../d2l-localize-behavior/d2l-localize-behavior.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.OrganizationInfo = window.D2L.PolymerBehaviors.OrganizationInfo || {};
+	/*
+	* @polymerBehavior D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior
+	*/
+	D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehaviorImpl = {
+		properties: {
+			locale: {
+				type: String,
+				value: function() {
+					return document.documentElement.lang
+						|| document.documentElement.getAttribute('data-lang-default')
+						|| 'en-us';
+				}
+			},
+			resources: {
+				value: function() {
+					return {
+						'en': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Closed {dateTime}',
+							'courseOpensOn': 'Opens on {dateTime}',
+							'inactive': 'Inactive',
+						},
+						'ar': {
+							'brackets': '({content})',
+							'courseClosedOn': 'تم الإغلاق في {dateTime}',
+							'courseOpensOn': 'يفتح في {dateTime}',
+							'inactive': 'غير نشط',
+						},
+						'de': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Geschlossen am {dateTime} um',
+							'courseOpensOn': 'Öffnet am {dateTime} um',
+							'inactive': 'Inaktiv',
+						},
+						'es': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Cerrado el {dateTime}',
+							'courseOpensOn': 'Se abre el día {dateTime}',
+							'inactive': 'Inactivo',
+						},
+						'fi': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Suljettu {dateTime}',
+							'courseOpensOn': 'Avautuu {dateTime}',
+							'inactive': 'Ei aktiivinen',
+						},
+						'fr': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Fermé le {dateTime} à',
+							'courseOpensOn': 'Ouvert le {dateTime} à',
+							'inactive': 'Inactif',
+						},
+						'ja': {
+							'brackets': '（{content}）',
+							'courseClosedOn': '{dateTime} にクローズ',
+							'courseOpensOn': '{dateTime} にオープン',
+							'inactive': '非アクティブ',
+						},
+						'ko': {
+							'brackets': '({content})',
+							'courseClosedOn': '닫힘 일시: {dateTime}',
+							'courseOpensOn': '열림 일시 {dateTime}',
+							'inactive': '비활성',
+						},
+						'nb': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Closed {dateTime}',
+							'courseOpensOn': 'Opens on {dateTime}',
+							'inactive': 'Inaktiv',
+						},
+						'nl': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Gesloten {dateTime}',
+							'courseOpensOn': 'Opent op {dateTime}',
+							'inactive': 'Inactief',
+						},
+						'pt': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Fechado em {dateTime}',
+							'courseOpensOn': 'Abre em {dateTime}',
+							'inactive': 'Inativo',
+						},
+						'sv': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Stängdes {dateTime}',
+							'courseOpensOn': 'Öppnas {dateTime}',
+							'inactive': 'Inaktiv',
+						},
+						'tr': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Şu tarihte kapandı: {dateTime}',
+							'courseOpensOn': 'Şu tarihte açılacak: {dateTime}',
+							'inactive': 'Etkin Değil',
+						},
+						'zh': {
+							'brackets': '({content})',
+							'courseClosedOn': '已于 {dateTime} 关闭',
+							'courseOpensOn': '于 {dateTime} 开启',
+							'inactive': '非活动',
+						},
+						'zh-tw': {
+							'brackets': '({content})',
+							'courseClosedOn': '關閉於 {dateTime}',
+							'courseOpensOn': '開啟於 {dateTime}',
+							'inactive': '停用',
+						}
+					};
+				}
+			}
+		}
+	};
+
+	/*
+	* @polymerBehavior D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior
+	*/
+	D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior = [
+		D2L.PolymerBehaviors.LocalizeBehavior,
+		D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehaviorImpl
+	];
+</script>

--- a/demo/d2l-organization-info.html
+++ b/demo/d2l-organization-info.html
@@ -24,7 +24,16 @@
 				<template>
 					<d2l-organization-info
 						presentation-href="data/presentation/1.json"
-						href="data/organization.json"></d2l-organization-info>
+						href="data/organization-future.json"></d2l-organization-info>
+					</d2l-organization-info>
+				</template>
+			</demo-snippet>
+
+			<demo-snippet>
+				<template>
+					<d2l-organization-info
+						presentation-href="data/presentation/1.json"
+						href="data/organization-past.json"></d2l-organization-info>
 					</d2l-organization-info>
 				</template>
 			</demo-snippet>
@@ -33,7 +42,7 @@
 				<template>
 					<d2l-organization-info
 						presentation-href="data/presentation/2.json"
-						href="data/organization.json">
+						href="data/organization-current.json">
 					</d2l-organization-info>
 				</template>
 			</demo-snippet>
@@ -42,7 +51,7 @@
 				<template>
 					<d2l-organization-info
 						presentation-href="data/presentation/3.json"
-						href="data/organization.json">
+						href="data/organization-current.json">
 					</d2l-organization-info>
 				</template>
 			</demo-snippet>

--- a/demo/data/organization-current.json
+++ b/demo/data/organization-current.json
@@ -1,0 +1,16 @@
+{
+  "properties": {
+    "name": "Course Name",
+    "code": "SCI100",
+    "startDate": null,
+    "endDate": null,
+    "isActive": true
+  },
+  "links": [{
+    "rel": ["self"],
+    "href": "data/organization.json"
+  }, {
+    "rel": ["https://api.brightspace.com/rels/parent-semester"],
+    "href": "data/semester.json"
+  }]
+}

--- a/demo/data/organization-future.json
+++ b/demo/data/organization-future.json
@@ -1,0 +1,16 @@
+{
+  "properties": {
+    "name": "Course Name",
+    "code": "SCI100",
+    "startDate": "2100-01-01T00:00:00.000Z",
+    "endDate": null,
+    "isActive": false
+  },
+  "links": [{
+    "rel": ["self"],
+    "href": "data/organization.json"
+  }, {
+    "rel": ["https://api.brightspace.com/rels/parent-semester"],
+    "href": "data/semester.json"
+  }]
+}

--- a/demo/data/organization-past.json
+++ b/demo/data/organization-past.json
@@ -1,7 +1,10 @@
 {
   "properties": {
     "name": "Course Name",
-    "code": "SCI100"
+    "code": "SCI100",
+    "startDate": null,
+    "endDate": "2000-01-01T00:00:00.000Z",
+    "isActive": true
   },
   "links": [{
     "rel": ["self"],

--- a/test/d2l-organization-info/d2l-organization-info.html
+++ b/test/d2l-organization-info/d2l-organization-info.html
@@ -17,7 +17,7 @@
 		<test-fixture id="with-href">
 			<template>
 				<d2l-organization-info
-					href="data/organization.json">
+					href="/organization.json">
 				</d2l-organization-info>
 			</template>
 		</test-fixture>
@@ -25,8 +25,26 @@
 		<test-fixture id="with-href-and-presentation-href">
 			<template>
 				<d2l-organization-info
-					href="data/organization.json"
-					presentation-href="data/presentation.json">
+					href="/organization.json"
+					presentation-href="/presentation.json">
+				</d2l-organization-info>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="future-organization">
+			<template>
+				<d2l-organization-info
+					href="/future-organization.json"
+					presentation-href="/presentation.json">
+				</d2l-organization-info>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="ended-organization">
+			<template>
+				<d2l-organization-info
+					href="/ended-organization.json"
+					presentation-href="/presentation.json">
 				</d2l-organization-info>
 			</template>
 		</test-fixture>


### PR DESCRIPTION
This isn't the fully-correct implementation, as that will involve adding the status badge between the header and content. However, this is a first pass, which moves the future/ended/inactive status of the organization into the `d2l-organization-info` component. This displays the same information that was previously displayed in the image overlay in the `d2l-enrollment-card`, meaning that can now be removed.