### PR TITLE
made d2l-card-content-meta a block instead inline-block.

### DIFF
--- a/components/d2l-organization-info/d2l-organization-info.html
+++ b/components/d2l-organization-info/d2l-organization-info.html
@@ -29,6 +29,10 @@
 				margin-top: 0.6rem;
 			}
 
+			d2l-card-content-meta {
+				display: block;
+			}
+
 		</style>
 
 		[[_organizationName]]


### PR DESCRIPTION
The course code would show up on the same line as the course title. It no longer does this.
I have a branch where I am splitting up `d2l-organization-info` However, that will take a little longer. So this is the fix for the current layout.