### PR TITLE
Split d2l-organization into smaller components.

### DIFF
--- a/all-imports.html
+++ b/all-imports.html
@@ -1,0 +1,4 @@
+<link rel="import" href="d2l-organization-name.html">
+<link rel="import" href="d2l-organization-date.html">
+<link rel="import" href="d2l-organization-info.html">
+<link rel="import" href="d2l-organization-updates.html">

--- a/components/d2l-organization-behavior.html
+++ b/components/d2l-organization-behavior.html
@@ -1,0 +1,34 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-fetch/d2l-fetch.html">
+<link rel="import" href="../../siren-parser-import/siren-parser.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.Organization = window.D2L.Organization || {};
+	/*
+	 *	Common methods used by organizations components.
+	 * @polymerBehavior D2L.Organization.Behavior
+	 */
+	D2L.Organization.Behavior = {
+		_fireD2lOrganizationAccessible: function(details) {
+			this.fire('d2l-organization-accessible', details);
+		},
+		_fetchSirenEntity: function(url) {
+				if (!url) {
+					return;
+				}
+
+				return window.d2lfetch
+					.fetch(new Request(url, {
+						headers: { Accept: 'application/vnd.siren+json' },
+					}))
+					.then(function(response) {
+						if (response.ok) {
+							return response.json();
+						}
+						return Promise.reject(response.status + ' ' + response.statusText);
+					})
+					.then(window.D2L.Hypermedia.Siren.Parse);
+			}
+	};
+</script>

--- a/components/d2l-organization-behavior.html
+++ b/components/d2l-organization-behavior.html
@@ -4,12 +4,13 @@
 
 <script>
 	window.D2L = window.D2L || {};
-	window.D2L.Organization = window.D2L.Organization || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.Organization = window.D2L.PolymerBehaviors.Organization || {};
 	/*
 	 *	Common methods used by organizations components.
-	 * @polymerBehavior D2L.Organization.Behavior
+	 * @polymerBehavior D2L.PolymerBehaviors.Organization.Behavior
 	 */
-	D2L.Organization.Behavior = {
+	D2L.PolymerBehaviors.Organization.Behavior = {
 		_fireD2lOrganizationAccessible: function(details) {
 			this.fire('d2l-organization-accessible', details);
 		},

--- a/components/d2l-organization-date/d2l-organization-date.html
+++ b/components/d2l-organization-date/d2l-organization-date.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../d2l-organization-behavior.html">
+<link rel="import" href="localize-behavior.html">
+
+<!--
+`d2l-organization-date`
+
+Polymer-based web component for a organization date such as start and end date for a course.
+
+@demo demo/d2l-organization-date/d2l-organization-date-demo.html Organization Name
+-->
+
+<dom-module id="d2l-organization-date">
+	<template strip-whitespace>
+		<span hidden$="[[!_statusText]]">[[_statusText]]</span>
+	</template>
+
+	<script>
+		Polymer({
+			is: 'd2l-organization-date',
+
+			properties: {
+				href: String,
+
+				_statusText: String
+			},
+
+			behaviors: [
+				D2L.PolymerBehaviors.OrganizationDate.LocalizeBehavior,
+				D2L.Organization.Behavior
+			],
+
+			observers: [
+				'_fetchOrganizationDate(href)',
+				'_sendVoiceReaderInfo(_statusText)'
+			],
+
+			_fetchOrganizationDate: function(organizationHref) {
+				return this._fetchSirenEntity(organizationHref)
+					.then(function(organizationEntity) {
+						this._statusText = null;
+
+						if (!organizationEntity) {
+							return;
+						}
+
+						if (!organizationEntity.properties) {
+							return;
+						}
+
+						var nowDate = Date.now();
+						var endDate = Date.parse(organizationEntity.properties.endDate);
+						var startDate = Date.parse(organizationEntity.properties.startDate);
+
+						if (endDate < nowDate) {
+							endDate = new Date(endDate);
+							this._statusText = this.localize('courseClosedOn', 'dateTime', this.formatDate(endDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(endDate));
+						} else if (startDate > nowDate) {
+							startDate = new Date(startDate);
+							this._statusText = this.localize('courseOpensOn', 'dateTime', this.formatDate(startDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(startDate));
+						}
+						if (this._statusText || !organizationEntity.properties.isActive) {
+							this.fire('d2l-organization-date', {
+								inactive: !organizationEntity.properties.isActive || startDate > nowDate,
+								isClosed:  endDate <= nowDate,
+								beforeStartDate: startDate > nowDate,
+								afterEndDate: endDate <= nowDate
+							});
+						}
+
+					}.bind(this));
+			},
+
+			_sendVoiceReaderInfo: function(statusText) {
+				if (!statusText) {
+					return;
+				}
+
+				var details = {
+					organization: {
+						date: statusText
+					},
+				};
+
+				this._fireD2lOrganizationAccessible(details);
+			},
+		});
+	</script>
+</dom-module>

--- a/components/d2l-organization-date/d2l-organization-date.html
+++ b/components/d2l-organization-date/d2l-organization-date.html
@@ -27,7 +27,7 @@ Polymer-based web component for a organization date such as start and end date f
 
 			behaviors: [
 				D2L.PolymerBehaviors.OrganizationDate.LocalizeBehavior,
-				D2L.Organization.Behavior
+				D2L.PolymerBehaviors.Organization.Behavior
 			],
 
 			observers: [

--- a/components/d2l-organization-date/localize-behavior.html
+++ b/components/d2l-organization-date/localize-behavior.html
@@ -1,0 +1,111 @@
+<link rel="import" href="../../../d2l-localize-behavior/d2l-localize-behavior.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+	window.D2L.PolymerBehaviors.OrganizationDate = window.D2L.PolymerBehaviors.OrganizationDate || {};
+	/*
+	* @polymerBehavior D2L.PolymerBehaviors.OrganizationDate.LocalizeBehavior
+	*/
+	D2L.PolymerBehaviors.OrganizationDate.LocalizeBehaviorImpl = {
+		properties: {
+			locale: {
+				type: String,
+				value: function() {
+					return document.documentElement.lang
+						|| document.documentElement.getAttribute('data-lang-default')
+						|| 'en-us';
+				}
+			},
+			resources: {
+				value: function() {
+					return {
+						'en': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Closed {dateTime}',
+							'courseOpensOn': 'Opens on {dateTime}',
+						},
+						'ar': {
+							'brackets': '({content})',
+							'courseClosedOn': 'تم الإغلاق في {dateTime}',
+							'courseOpensOn': 'يفتح في {dateTime}',
+						},
+						'de': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Geschlossen am {dateTime} um',
+							'courseOpensOn': 'Öffnet am {dateTime} um',
+						},
+						'es': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Cerrado el {dateTime}',
+							'courseOpensOn': 'Se abre el día {dateTime}',
+						},
+						'fi': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Suljettu {dateTime}',
+							'courseOpensOn': 'Avautuu {dateTime}',
+						},
+						'fr': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Fermé le {dateTime} à',
+							'courseOpensOn': 'Ouvert le {dateTime} à',
+						},
+						'ja': {
+							'brackets': '（{content}）',
+							'courseClosedOn': '{dateTime} にクローズ',
+							'courseOpensOn': '{dateTime} にオープン',
+						},
+						'ko': {
+							'brackets': '({content})',
+							'courseClosedOn': '닫힘 일시: {dateTime}',
+							'courseOpensOn': '열림 일시 {dateTime}',
+						},
+						'nb': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Closed {dateTime}',
+							'courseOpensOn': 'Opens on {dateTime}',
+						},
+						'nl': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Gesloten {dateTime}',
+							'courseOpensOn': 'Opent op {dateTime}',
+						},
+						'pt': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Fechado em {dateTime}',
+							'courseOpensOn': 'Abre em {dateTime}',
+						},
+						'sv': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Stängdes {dateTime}',
+							'courseOpensOn': 'Öppnas {dateTime}',
+						},
+						'tr': {
+							'brackets': '({content})',
+							'courseClosedOn': 'Şu tarihte kapandı: {dateTime}',
+							'courseOpensOn': 'Şu tarihte açılacak: {dateTime}',
+						},
+						'zh': {
+							'brackets': '({content})',
+							'courseClosedOn': '已于 {dateTime} 关闭',
+							'courseOpensOn': '于 {dateTime} 开启',
+						},
+						'zh-tw': {
+							'brackets': '({content})',
+							'courseClosedOn': '關閉於 {dateTime}',
+							'courseOpensOn': '開啟於 {dateTime}',
+						}
+					};
+				}
+			}
+		}
+	};
+
+	/*
+	* @polymerBehavior D2L.PolymerBehaviors.OrganizationDate.LocalizeBehavior
+	*/
+	D2L.PolymerBehaviors.OrganizationDate.LocalizeBehavior = [
+		D2L.PolymerBehaviors.LocalizeBehavior,
+		D2L.PolymerBehaviors.OrganizationDate.LocalizeBehaviorImpl
+	];
+</script>

--- a/components/d2l-organization-info/d2l-organization-info.html
+++ b/components/d2l-organization-info/d2l-organization-info.html
@@ -1,11 +1,18 @@
 <link rel="import" href="../../../polymer/polymer.html">
-<link rel="import" href="../../../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../../d2l-icons/tier1-icons.html">
-<link rel="import" href="../../../d2l-tile/d2l-card-content-meta.html">
 <link rel="import" href="../../../siren-parser-import/siren-parser.html">
+<link rel="import" href="../d2l-organization-behavior.html">
 <link rel="import" href="localize-behavior.html">
+
+<!--
+`d2l-organization-info`
+
+Polymer-based web component for a organization info such as course code and semester name.
+
+@demo demo/d2l-organization-info/d2l-organization-info-demo.html Organization Name
+-->
 
 <dom-module id="d2l-organization-info">
 	<template strip-whitespace>
@@ -23,29 +30,13 @@
 				text-transform: uppercase;
 			}
 
-			.flex:not([hidden]) {
-				display: flex;
-				flex-direction: column;
-				margin-top: 0.6rem;
-			}
-
-			d2l-card-content-meta {
-				display: block;
-			}
-
 		</style>
 
-		[[_organizationName]]
-		<d2l-card-content-meta>
+		<span>
 			<span hidden$="[[!_showOrganizationCode]]" class="uppercase">[[_organizationCode]]</span>
 			<d2l-icon hidden$="[[!_showSeparator]]" icon="d2l-tier1:bullet"></d2l-icon>
 			<span hidden$="[[!_showSemesterName]]">[[_semesterName]]</span>
-		</d2l-card-content-meta>
-		<d2l-card-content-meta class="flex" hidden$="[[!_hasStatusText]]">
-			<span hidden$="[[!_statusTextEnded]]">[[_statusTextEnded]]</span>
-			<span hidden$="[[!_statusTextFuture]]">[[_statusTextFuture]]</span>
-			<span hidden$="[[!_statusTextInactive]]">[[_statusTextInactive]]</span>
-		</d2l-card-content-meta>
+		</span>
 	</template>
 
 	<script>
@@ -56,14 +47,8 @@
 				href: String,
 				presentationHref: String,
 
-				_hasStatusText: {
-					type: Boolean,
-					value: false,
-					computed: '_computeHasStatusText(_statusTextEnded, _statusTextFuture, _statusTextInactive)'
-				},
 				_organization: Object,
 				_organizationCode: String,
-				_organizationName: String,
 				_semesterName: String,
 				_showOrganizationCode: {
 					type: Boolean,
@@ -77,28 +62,21 @@
 					type: Boolean,
 					value: false,
 					computed: '_computeShowSeparator(_showOrganizationCode, _showSemesterName, _organizationCode, _semesterName)'
-				},
-				_statusTextEnded: String,
-				_statusTextFuture: String,
-				_statusTextInactive: String
+				}
 			},
 
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
-				D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior
+				D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior,
+				D2L.Organization.Behavior
 			],
 
 			observers: [
 				'_fetchOrganization(href)',
 				'_fetchPresentation(presentationHref)',
 				'_fetchSemester(_organization, _showSemesterName)',
-				'_fireVoiceReaderInfo(_organizationName, _showOrganizationCode, _showSemesterName, _organizationCode, _semesterName)'
+				'_sendVoiceReaderInfo(_showOrganizationCode, _showSemesterName, _organizationCode, _semesterName)'
 			],
-
-			_computeHasStatusText: function(statusTextEnded, statusTextFuture, statusTextInactive) {
-				return statusTextEnded || statusTextFuture || statusTextInactive;
-			},
-
 			_computeShowSeparator: function(showOrganizationCode, showSemester, organizationCode, semesterName) {
 				return showSemester
 					&& showOrganizationCode
@@ -124,24 +102,7 @@
 							return;
 						}
 
-						this._organizationName = organizationEntity.properties.name;
 						this._organizationCode = organizationEntity.properties.code;
-
-						if (!organizationEntity.properties.isActive) {
-							this._statusTextInactive = this.localize('brackets', 'content', this.localize('inactive'));
-						}
-
-						var nowDate = Date.now();
-						var endDate = Date.parse(organizationEntity.properties.endDate);
-						var startDate = Date.parse(organizationEntity.properties.startDate);
-
-						if (endDate < nowDate) {
-							endDate = new Date(endDate);
-							this._statusTextEnded = this.localize('courseClosedOn', 'dateTime', this.formatDate(endDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(endDate));
-						} else if (startDate > nowDate) {
-							startDate = new Date(startDate);
-							this._statusTextFuture = this.localize('courseOpensOn', 'dateTime', this.formatDate(startDate, {format: 'MMMM d, yyyy'}) + ' ' + this.formatTime(startDate));
-						}
 					}.bind(this));
 			},
 
@@ -178,35 +139,16 @@
 					}.bind(this));
 			},
 
-			_fireVoiceReaderInfo: function(organizationName, showOrganizationCode, showSemesterName, organizationCode, semesterName) {
+			_sendVoiceReaderInfo: function(showOrganizationCode, showSemesterName, organizationCode, semesterName) {
 				var details = {
 					organization: {
-						name: organizationName,
 						code: showOrganizationCode && organizationCode
 					},
 					semesterName: showSemesterName && semesterName
 				};
 
-				this.fire('d2l-organization-accessible', details);
+				this._fireD2lOrganizationAccessible(details);
 			},
-
-			_fetchSirenEntity: function(url) {
-				if (!url) {
-					return;
-				}
-
-				return window.d2lfetch
-					.fetch(new Request(url, {
-						headers: { Accept: 'application/vnd.siren+json' },
-					}))
-					.then(function(response) {
-						if (response.ok) {
-							return response.json();
-						}
-						return Promise.reject(response.status + ' ' + response.statusText);
-					})
-					.then(window.D2L.Hypermedia.Siren.Parse);
-			}
 		});
 	</script>
 </dom-module>

--- a/components/d2l-organization-info/d2l-organization-info.html
+++ b/components/d2l-organization-info/d2l-organization-info.html
@@ -68,7 +68,7 @@ Polymer-based web component for a organization info such as course code and seme
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.OrganizationInfo.LocalizeBehavior,
-				D2L.Organization.Behavior
+				D2L.PolymerBehaviors.Organization.Behavior
 			],
 
 			observers: [

--- a/components/d2l-organization-name/d2l-organization-name.html
+++ b/components/d2l-organization-name/d2l-organization-name.html
@@ -25,7 +25,7 @@ Polymer-based web component for a organization name.
 			},
 
 			behaviors: [
-				D2L.Organization.Behavior
+				D2L.PolymerBehaviors.Organization.Behavior
 			],
 
 			observers: [

--- a/components/d2l-organization-name/d2l-organization-name.html
+++ b/components/d2l-organization-name/d2l-organization-name.html
@@ -1,0 +1,62 @@
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../d2l-organization-behavior.html">
+
+<!--
+`d2l-organization-name`
+
+Polymer-based web component for a organization name.
+
+@demo demo/d2l-organization-name/d2l-organization-name-demo.html Organization Name
+-->
+
+<dom-module id="d2l-organization-name">
+	<template strip-whitespace>
+		[[_organizationName]]
+	</template>
+
+	<script>
+		Polymer({
+			is: 'd2l-organization-name',
+
+			properties: {
+				href: String,
+
+				_organizationName: String
+			},
+
+			behaviors: [
+				D2L.Organization.Behavior
+			],
+
+			observers: [
+				'_fetchOrganization(href)',
+				'_sendVoiceReaderInfo(_organizationName)'
+			],
+
+			_fetchOrganization: function(organizationHref) {
+				return this._fetchSirenEntity(organizationHref)
+					.then(function(organizationEntity) {
+						if (!organizationEntity) {
+							return;
+						}
+
+						if (!organizationEntity.properties) {
+							return;
+						}
+
+						this._organizationName = organizationEntity.properties.name;
+					}.bind(this));
+			},
+
+			_sendVoiceReaderInfo: function(organizationName) {
+				var details = {
+					organization: {
+						name: organizationName
+					}
+				};
+
+				this._fireD2lOrganizationAccessible(details);
+			},
+		});
+	</script>
+</dom-module>

--- a/d2l-organization-date.html
+++ b/d2l-organization-date.html
@@ -1,0 +1,1 @@
+<link rel="import" href="components/d2l-organization-date/d2l-organization-date.html">

--- a/d2l-organization-name.html
+++ b/d2l-organization-name.html
@@ -1,0 +1,1 @@
+<link rel="import" href="components/d2l-organization-name/d2l-organization-name.html">

--- a/demo/d2l-organization-date/d2l-organization-date-demo.html
+++ b/demo/d2l-organization-date/d2l-organization-date-demo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-organization demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../components/d2l-organization-date/d2l-organization-date.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>d2l-organization-date: future</h3>
+			<demo-snippet>
+				<template>
+					<d2l-organization-date
+						href="../data/organization-future.json">
+					</d2l-organization-date>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-organization-date: past</h3>
+			<demo-snippet>
+				<template>
+					<d2l-organization-date
+						href="../data/organization-past.json">
+					</d2l-organization-date>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-organization-date: current</h3>
+			<demo-snippet>
+				<template>
+					<d2l-organization-date
+						href="../data/organization-current.json">
+					</d2l-organization-date>
+				</template>
+			</demo-snippet>
+
+		</div>
+	</body>
+
+	<!-- The class="d2l-typography" on the body doesn't always work -->
+	<script>document.querySelector('body').classList.add('d2l-typography');</script>
+</html>

--- a/demo/d2l-organization-info/d2l-organization-info-demo.html
+++ b/demo/d2l-organization-info/d2l-organization-info-demo.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-organization demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../components/d2l-organization-info/d2l-organization-info.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>d2l-organization-info</h3>
+			<demo-snippet>
+				<template>
+					<d2l-organization-info
+						presentation-href="../data/presentation/1.json"
+						href="../data/organization-current.json">
+					</d2l-organization-info>
+				</template>
+			</demo-snippet>
+
+			<demo-snippet>
+				<template>
+					<d2l-organization-info
+						presentation-href="../data/presentation/2.json"
+						href="../data/organization-current.json">
+					</d2l-organization-info>
+				</template>
+			</demo-snippet>
+
+			<demo-snippet>
+				<template>
+					<d2l-organization-info
+						presentation-href="../data/presentation/3.json"
+						href="../data/organization-current.json">
+					</d2l-organization-info>
+				</template>
+			</demo-snippet>
+
+		</div>
+	</body>
+
+	<!-- The class="d2l-typography" on the body doesn't always work -->
+	<script>document.querySelector('body').classList.add('d2l-typography');</script>
+</html>

--- a/demo/d2l-organization-name/d2l-organization-name-demo.html
+++ b/demo/d2l-organization-name/d2l-organization-name-demo.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-organization demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../components/d2l-organization-name/d2l-organization-name.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles"></style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container centered">
+
+			<h3>d2l-organization-name</h3>
+			<demo-snippet>
+				<template>
+					<d2l-organization-name href="../data/organization-current.json"></d2l-organization-name>
+				</template>
+			</demo-snippet>
+
+		</div>
+	</body>
+
+	<!-- The class="d2l-typography" on the body doesn't always work -->
+	<script>document.querySelector('body').classList.add('d2l-typography');</script>
+</html>

--- a/demo/data/organization-current.json
+++ b/demo/data/organization-current.json
@@ -11,6 +11,6 @@
     "href": "data/organization.json"
   }, {
     "rel": ["https://api.brightspace.com/rels/parent-semester"],
-    "href": "data/semester.json"
+    "href": "../data/semester.json"
   }]
 }

--- a/demo/data/organization-future.json
+++ b/demo/data/organization-future.json
@@ -11,6 +11,6 @@
     "href": "data/organization.json"
   }, {
     "rel": ["https://api.brightspace.com/rels/parent-semester"],
-    "href": "data/semester.json"
+    "href": "../data/semester.json"
   }]
 }

--- a/demo/data/organization-past.json
+++ b/demo/data/organization-past.json
@@ -11,6 +11,6 @@
     "href": "data/organization.json"
   }, {
     "rel": ["https://api.brightspace.com/rels/parent-semester"],
-    "href": "data/semester.json"
+    "href": "../data/semester.json"
   }]
 }

--- a/demo/data/presentation/1.json
+++ b/demo/data/presentation/1.json
@@ -1,12 +1,7 @@
 {
   "properties": {
     "ShowCourseCode": true,
-    "ShowSemester": true,
-    "ShowUnattemptedQuizzes": true,
-    "ShowDropboxUnreadFeedback": true,
-    "ShowUngradedQuizAttempts": true,
-    "ShowUnreadDiscussionMessages": true,
-    "ShowUnreadDropboxSubmissions": true
+    "ShowSemester": true
   },
   "links": [{
     "rel": ["self"],

--- a/demo/data/presentation/2.json
+++ b/demo/data/presentation/2.json
@@ -1,12 +1,7 @@
 {
   "properties": {
     "ShowCourseCode": true,
-    "ShowSemester": false,
-    "ShowUnattemptedQuizzes": true,
-    "ShowDropboxUnreadFeedback": true,
-    "ShowUngradedQuizAttempts": true,
-    "ShowUnreadDiscussionMessages": false,
-    "ShowUnreadDropboxSubmissions": true
+    "ShowSemester": false
   },
   "links": [{
     "rel": ["self"],

--- a/demo/data/presentation/3.json
+++ b/demo/data/presentation/3.json
@@ -1,8 +1,7 @@
 {
   "properties": {
     "ShowCourseCode": false,
-    "ShowSemester": false,
-    "ShowUnattemptedQuizzes":true
+    "ShowSemester": false
   },
   "links": [{
     "rel": ["self"],

--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>
 	<body>
-		<iron-component-page></iron-component-page>
+		<iron-component-page src="all-imports.html"></iron-component-page>
 	</body>
 </html>

--- a/test/d2l-organization-date/d2l-organization-date.html
+++ b/test/d2l-organization-date/d2l-organization-date.html
@@ -1,0 +1,40 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="../../components/d2l-organization-date/d2l-organization-date.html">
+	</head>
+	<body>
+		<test-fixture id="no-params">
+			<template>
+				<d2l-organization-date></d2l-organization-date>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="with-href">
+			<template>
+				<d2l-organization-date href="/organization.json">
+				</d2l-organization-date>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="future-organization">
+			<template>
+				<d2l-organization-date href="/future-organization.json">
+				</d2l-organization-date>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="ended-organization">
+			<template>
+				<d2l-organization-date href="/ended-organization.json">
+				</d2l-organization-date>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-organization-date.js"></script>
+	</body>
+</html>

--- a/test/d2l-organization-date/d2l-organization-date.js
+++ b/test/d2l-organization-date/d2l-organization-date.js
@@ -1,0 +1,203 @@
+describe('d2l-organization-info', () => {
+	var sandbox,
+		component,
+		fetchStub;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+
+		var organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+			properties: {
+				name: 'Course Name',
+				code: 'SCI100',
+				startDate: null,
+				endDate: null,
+				isActive: false
+			},
+			links: [{
+				rel: ['https://api.brightspace.com/rels/parent-semester'],
+				href: '/semester.json'
+			}]
+		});
+		var futureOrganization = window.D2L.Hypermedia.Siren.Parse({
+			properties: {
+				name: 'Course Name',
+				code: 'SCI100',
+				startDate: '2099-01-01T00:00:00.000Z',
+				endDate: '2100-01-01T00:00:00.000Z',
+				isActive: true
+			},
+			links: [{
+				rel: ['https://api.brightspace.com/rels/parent-semester'],
+				href: '/semester.json'
+			}]
+		});
+		var endedOrganization = window.D2L.Hypermedia.Siren.Parse({
+			properties: {
+				name: 'Course Name',
+				code: 'SCI100',
+				startDate: '1999-01-01T00:00:00.000Z',
+				endDate: '2000-01-01T00:00:00.000Z',
+				isActive: true
+			},
+			links: [{
+				rel: ['https://api.brightspace.com/rels/parent-semester'],
+				href: '/semester.json'
+			}]
+		});
+
+		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
+		fetchStub
+			.withArgs(sinon.match.has('url', sinon.match('/organization.json')))
+			.returns(Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(organizationEntity); }
+			}))
+			.withArgs(sinon.match.has('url', sinon.match('/future-organization.json')))
+			.returns(Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(futureOrganization); }
+			}))
+			.withArgs(sinon.match.has('url', sinon.match('/ended-organization.json')))
+			.returns(Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(endedOrganization); }
+			}));
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('observers', () => {
+		beforeEach(() => {
+			component = fixture('no-params');
+		});
+
+		it('should call _fetchOrganizationDate upon changes to href', () => {
+			var spy = sandbox.spy(component, '_fetchOrganizationDate');
+			component.href = '/organization.json';
+			expect(spy).to.have.been.called;
+		});
+
+		it('should call _sendVoiceReaderInfo upon changes to _statusText', () => {
+			var spy = sandbox.spy(component, '_sendVoiceReaderInfo');
+
+			component._statusText = '';
+			expect(spy).to.have.been.calledOnce;
+		});
+
+	});
+
+	describe('fetching organization', () => {
+		beforeEach(done => {
+			component = fixture('future-organization');
+
+			setTimeout(() => {
+				done();
+			}, 100);
+		});
+
+		it('should set the _statusText', () => {
+			expect(component._statusText).to.equal('Opens on December 31, 2098 7:00 PM');
+		});
+	});
+
+	describe('status text', () => {
+		it('should display the "Opens on" text when organization starts in future', done => {
+			component = fixture('future-organization');
+
+			setTimeout(() => {
+				var text = component.$$('span:not([hidden])');
+				expect(text.innerText).to.contain('Opens on ');
+				done();
+			});
+
+		});
+
+		it('should display the "Closed" text when organization ends in past', done => {
+			component = fixture('ended-organization');
+
+			setTimeout(() => {
+				var text = component.$$('span:not([hidden])');
+				expect(text.innerText).to.contain('Closed');
+				done();
+			});
+
+		});
+
+		it('should display the nothing when organization is inactive and is after start date or has no start date', done => {
+			component = fixture('with-href');
+
+			setTimeout(() => {
+				var text = component.$$('span:not([hidden])');
+				expect(text).to.be.null;
+				done();
+			});
+
+		});
+
+	});
+
+	describe('Events', () => {
+		beforeEach(() => {
+			component = fixture('no-params');
+		});
+
+		it('should send event with detail of inactive and before start date as true when organization starts in future.', done => {
+			component.addEventListener('d2l-organization-date', function(e) {
+				expect(e.detail.beforeStartDate).to.be.true;
+				expect(e.detail.inactive).to.be.true;
+				expect(e.detail.isClosed).to.be.false;
+				expect(e.detail.afterEndDate).to.be.false;
+				done();
+			});
+			component.href = '/future-organization.json';
+
+		});
+
+		it('should send event with detail of is closed and after end date to be true when organization ends in past.', done => {
+			component.addEventListener('d2l-organization-date', function(e) {
+				expect(e.detail.beforeStartDate).to.be.false;
+				expect(e.detail.inactive).to.be.false;
+				expect(e.detail.isClosed).to.be.true;
+				expect(e.detail.afterEndDate).to.be.true;
+				done();
+			});
+			component.href = '/ended-organization.json';
+
+		});
+
+		it('should have inactive true and the rest false when organization is inactive without start date.', done => {
+			component.addEventListener('d2l-organization-date', function(e) {
+				expect(e.detail.beforeStartDate).to.be.false;
+				expect(e.detail.inactive).to.be.true;
+				expect(e.detail.isClosed).to.be.false;
+				expect(e.detail.afterEndDate).to.be.false;
+				done();
+			});
+			component.href = '/organization.json';
+
+		});
+
+		it('should send the "Opens on" text when organization starts in future', done => {
+			component.addEventListener('d2l-organization-accessible', function(e) {
+				expect(e.detail.organization.date).to.contain('Opens on ');
+				done();
+			});
+			component.href = '/future-organization.json';
+
+		});
+
+		it('should send the "Closed" text when organization ends in past', done => {
+			component.addEventListener('d2l-organization-accessible', function(e) {
+				expect(e.detail.organization.date).to.contain('Closed');
+				done();
+			});
+			component.href = '/ended-organization.json';
+
+		});
+
+	});
+
+});

--- a/test/d2l-organization-date/d2l-organization-date.js
+++ b/test/d2l-organization-date/d2l-organization-date.js
@@ -1,4 +1,4 @@
-describe('d2l-organization-info', () => {
+describe('d2l-organization-date', () => {
 	var sandbox,
 		component,
 		fetchStub;
@@ -6,7 +6,7 @@ describe('d2l-organization-info', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 
-		var organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+		var organizationEntity = {
 			properties: {
 				name: 'Course Name',
 				code: 'SCI100',
@@ -18,8 +18,8 @@ describe('d2l-organization-info', () => {
 				rel: ['https://api.brightspace.com/rels/parent-semester'],
 				href: '/semester.json'
 			}]
-		});
-		var futureOrganization = window.D2L.Hypermedia.Siren.Parse({
+		};
+		var futureOrganization = {
 			properties: {
 				name: 'Course Name',
 				code: 'SCI100',
@@ -31,8 +31,8 @@ describe('d2l-organization-info', () => {
 				rel: ['https://api.brightspace.com/rels/parent-semester'],
 				href: '/semester.json'
 			}]
-		});
-		var endedOrganization = window.D2L.Hypermedia.Siren.Parse({
+		};
+		var endedOrganization = {
 			properties: {
 				name: 'Course Name',
 				code: 'SCI100',
@@ -44,7 +44,7 @@ describe('d2l-organization-info', () => {
 				rel: ['https://api.brightspace.com/rels/parent-semester'],
 				href: '/semester.json'
 			}]
-		});
+		};
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		fetchStub

--- a/test/d2l-organization-date/d2l-organization-date.js
+++ b/test/d2l-organization-date/d2l-organization-date.js
@@ -99,7 +99,7 @@ describe('d2l-organization-info', () => {
 		});
 
 		it('should set the _statusText', () => {
-			expect(component._statusText).to.equal('Opens on December 31, 2098 7:00 PM');
+			expect(component._statusText).to.contain('Opens on ');
 		});
 	});
 

--- a/test/d2l-organization-info/d2l-organization-info.js
+++ b/test/d2l-organization-info/d2l-organization-info.js
@@ -6,7 +6,7 @@ describe('d2l-organization-info', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 
-		var organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+		var organizationEntity = {
 			properties: {
 				name: 'Course Name',
 				code: 'SCI100',
@@ -18,18 +18,18 @@ describe('d2l-organization-info', () => {
 				rel: ['https://api.brightspace.com/rels/parent-semester'],
 				href: '/semester.json'
 			}]
-		});
-		var semesterEntity = window.D2L.Hypermedia.Siren.Parse({
+		};
+		var semesterEntity = {
 			properties: {
 				name: 'Semester Name'
 			}
-		});
-		var presentationEntity = window.D2L.Hypermedia.Siren.Parse({
+		};
+		var presentationEntity = {
 			properties: {
 				ShowCourseCode: true,
 				ShowSemester: true
 			}
-		});
+		};
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		fetchStub

--- a/test/d2l-organization-name/d2l-organization-name.html
+++ b/test/d2l-organization-name/d2l-organization-name.html
@@ -5,32 +5,23 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../components/d2l-organization-info/d2l-organization-info.html">
+		<link rel="import" href="../../components/d2l-organization-name/d2l-organization-name.html">
 	</head>
 	<body>
 		<test-fixture id="no-params">
 			<template>
-				<d2l-organization-info></d2l-organization-info>
+				<d2l-organization-name></d2l-organization-name>
 			</template>
 		</test-fixture>
 
 		<test-fixture id="with-href">
 			<template>
-				<d2l-organization-info
+				<d2l-organization-name
 					href="/organization.json">
-				</d2l-organization-info>
+				</d2l-organization-name>
 			</template>
 		</test-fixture>
 
-		<test-fixture id="with-href-and-presentation-href">
-			<template>
-				<d2l-organization-info
-					href="/organization.json"
-					presentation-href="/presentation.json">
-				</d2l-organization-info>
-			</template>
-		</test-fixture>
-
-		<script src="d2l-organization-info.js"></script>
+		<script src="d2l-organization-name.js"></script>
 	</body>
 </html>

--- a/test/d2l-organization-name/d2l-organization-name.js
+++ b/test/d2l-organization-name/d2l-organization-name.js
@@ -1,0 +1,87 @@
+describe('d2l-organization-name', () => {
+	var sandbox,
+		component,
+		fetchStub;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+
+		var organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+			properties: {
+				name: 'Course Name',
+				code: 'SCI100',
+				startDate: null,
+				endDate: null,
+				isActive: false
+			},
+			links: [{
+				rel: ['https://api.brightspace.com/rels/parent-semester'],
+				href: '/semester.json'
+			}]
+		});
+
+		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
+		fetchStub
+			.withArgs(sinon.match.has('url', sinon.match('/organization.json')))
+			.returns(Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(organizationEntity); }
+			}));
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('observers', () => {
+		beforeEach(() => {
+			component = fixture('no-params');
+		});
+
+		it('should call _fetchOrganization upon changes to href', () => {
+			var spy = sandbox.spy(component, '_fetchOrganization');
+			component.href = '/organization.json';
+			expect(spy).to.have.been.called;
+		});
+
+		it('should call _sendVoiceReaderInfo upon changes to _organizationName', () => {
+			var spy = sandbox.spy(component, '_sendVoiceReaderInfo');
+
+			component._organizationName = 'Course Name';
+			expect(spy).to.have.been.calledOnce;
+		});
+
+	});
+
+	describe('fetching organization', () => {
+		beforeEach(done => {
+			component = fixture('with-href');
+
+			setTimeout(() => {
+				done();
+			}, 100);
+		});
+
+		it('should set the _organizationName', () => {
+			expect(component._organizationName).to.equal('Course Name');
+		});
+
+	});
+
+	describe('Events', () => {
+		beforeEach(() => {
+			component = fixture('no-params');
+		});
+
+		it('should send the "Closed" text when organization ends in past', done => {
+			component.addEventListener('d2l-organization-accessible', function(e) {
+				expect(e.detail.organization.name).to.contain('Another Course Name');
+				done();
+			});
+			component._organizationName = 'Another Course Name';
+
+		});
+
+	});
+
+});

--- a/test/d2l-organization-name/d2l-organization-name.js
+++ b/test/d2l-organization-name/d2l-organization-name.js
@@ -6,7 +6,7 @@ describe('d2l-organization-name', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 
-		var organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+		var organizationEntity = {
 			properties: {
 				name: 'Course Name',
 				code: 'SCI100',
@@ -18,7 +18,7 @@ describe('d2l-organization-name', () => {
 				rel: ['https://api.brightspace.com/rels/parent-semester'],
 				href: '/semester.json'
 			}]
-		});
+		};
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		fetchStub

--- a/test/d2l-organization-updates/d2l-organization-updates.js
+++ b/test/d2l-organization-updates/d2l-organization-updates.js
@@ -16,7 +16,7 @@ describe('d2l-organization-updates', () => {
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 
-		notificationEntity = window.D2L.Hypermedia.Siren.Parse({
+		notificationEntity = {
 			properties: {
 				UnattemptedQuizzes: -20,
 				UnreadAssignmentFeedback: 0,
@@ -29,8 +29,8 @@ describe('d2l-organization-updates', () => {
 				rel: ['self'],
 				href: '/data/notification.json'
 			}]
-		});
-		presentationEntity = window.D2L.Hypermedia.Siren.Parse({
+		};
+		presentationEntity = {
 			properties: {
 				ShowCourseCode: true,
 				ShowSemester: true,
@@ -40,7 +40,7 @@ describe('d2l-organization-updates', () => {
 				ShowUnreadDiscussionMessages: true,
 				ShowUnreadDropboxSubmissions: true
 			}
-		});
+		};
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		SetupFetchStub('/notification.json', notificationEntity);

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,11 @@
 				'./d2l-organization-info/d2l-organization-info.html?wc-shadydom=true',
 				'./d2l-organization-info/d2l-organization-info.html?dom=shadow',
 				'./d2l-organization-updates/d2l-organization-updates.html?wc-shadydom=true',
-				'./d2l-organization-updates/d2l-organization-updates.html?dom=shadow'
+				'./d2l-organization-updates/d2l-organization-updates.html?dom=shadow',
+				'./d2l-organization-name/d2l-organization-name.html?wc-shadydom=true',
+				'./d2l-organization-name/d2l-organization-name.html?dom=shadow',
+				'./d2l-organization-date/d2l-organization-date.html?wc-shadydom=true',
+				'./d2l-organization-date/d2l-organization-date.html?dom=shadow'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
Split d2l-organization-date into its own component.
Split d2l-organization-name into its own component.
d2l-organization-info no longer has the above information.
d2l-organization-info offers info such as course code and semester name.
Added demos for each of the components.