### PR TITLE
remove whitelist from constorium tabs component

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -9,7 +9,6 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { ConsortiumRootEntity } from 'siren-sdk/src/consortium/ConsortiumRootEntity.js';
 import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/ConsortiumTokenCollectionEntity.js';
-window.D2L.Siren.WhitelistBehavior._testMode(true);
 import '../d2l-organization-behavior.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-polymer-behaviors/d2l-id.js';


### PR DESCRIPTION
This shouldn't have been added to a main component, it only belongs in tests and demo pages