### PR TITLE
add render threshold (d2l-organization-consortium-tabs)

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -26,13 +26,19 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 
 	static get properties() {
 		return {
+			pollIntervalInSeconds: {
+				type: Number,
+				reflectToAttribute: true,
+				value: 300
+			},
 			selected: {
 				type: String,
 				reflectToAttribute: true
 			},
-			pollIntervalInSeconds: {
+			tabRenderThreshold: {
 				type: Number,
-				value: 300
+				reflectToAttribute: true,
+				value: 2
 			},
 			_organizations: {
 				type: Object,
@@ -183,7 +189,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 
 	_computeParsedOrganizations() {
 		const currentOrganizations = this._organizations;
-		return Object.keys(currentOrganizations).map(function(key) {
+		const orgs = Object.keys(currentOrganizations).map(function(key) {
 			const org = {
 				id: D2L.Id.getUniqueId(),
 				name: key,
@@ -193,7 +199,9 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 			};
 			return org;
 		});
+		return orgs.length >= this.tabRenderThreshold ? orgs : []; //don't render anything if we don't pass our render threshold
 	}
+
 }
 
 window.customElements.define(OrganizationConsortiumTabs.is, OrganizationConsortiumTabs);

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -58,6 +58,20 @@ describe('d2l-organization-consortium-tabs', () => {
 			});
 		});
 
+		it('threshold greater than the number of tabs causes no render', (done) => {
+			const component = fixture('org-consortium');
+			component.href = '/consortium-root1.json';
+			component.tabRenderThreshold = 7;
+
+			flush(function() {
+				const tabs = component.shadowRoot.querySelectorAll('a');
+				assert.equal(tabs.length, 0, 'should have no tabs');
+				const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
+				assert.equal(dots.length, 0, 'should have no notification dots');
+				done();
+			});
+		});
+
 		it('alerts use correct token', (done) => {
 			const component = fixture('org-consortium');
 			component.href = '/consortium-root1.json';


### PR DESCRIPTION
This change allows the component to be configured externally allowing us to let the lms control when to render out the tabs.

The default of 2 was picked as that seems to be the most likely scenario required.