### PR TITLE
Add href to loaded events and stop-gap timeout before firing loaded events

### DIFF
--- a/components/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/components/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -488,10 +488,13 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 
 		const loadedEvent = new CustomEvent(
 			'd2l-organization-detail-card-text-loaded',
-			{ composed: true, bubbles: true }
+			{ composed: true, bubbles: true, detail: { href: this._organizationUrl } }
 		);
-		this.dispatchEvent(loadedEvent);
-		this._isTextLoaded = true;
+		// Stop-gap solution to delay loaded event firing until the module sequences have loaded until we can get the sequence count from the siren-sdk
+		setTimeout(() => {
+			this.dispatchEvent(loadedEvent);
+			this._isTextLoaded = true;
+		}, 200);
 	}
 	_onSequenceRootChange(sequenceRoot) {
 		const modulesBySequence = [];
@@ -522,10 +525,13 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 	_onImageLoaded() {
 		const loadedEvent = new CustomEvent(
 			'd2l-organization-detail-card-image-loaded',
-			{ composed: true, bubbles: true }
+			{ composed: true, bubbles: true, detail: { href: this._organizationUrl } }
 		);
-		this.dispatchEvent(loadedEvent);
-		this._isImageLoaded = true;
+		// Stop-gap solution to delay loaded event firing until the module sequences have loaded until we can get the sequence count from the siren-sdk
+		setTimeout(() => {
+			this.dispatchEvent(loadedEvent);
+			this._isImageLoaded = true;
+		}, 200);
 	}
 	_resetCompletion() {
 		this._modulesComplete = {

--- a/test/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/test/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -116,7 +116,7 @@ describe('d2l-organization-detail-card', () => {
 			setTimeout(() => {
 				sinon.assert.called(eventSpy);
 				done();
-			});
+			}, 250);
 
 		});
 
@@ -131,7 +131,7 @@ describe('d2l-organization-detail-card', () => {
 			setTimeout(() => {
 				sinon.assert.called(eventSpy);
 				done();
-			});
+			}, 250);
 
 		});
 


### PR DESCRIPTION
# Changes
1. Add href to loaded events to be able to determine which `d2l-organization-detail-card` fired the event.
1. Add stop-gap solution to delay loaded event firing until the module sequences have loaded until we can get the sequence count from the siren-sdk.