### PR TITLE
using iron-icon instead of d2l-icon with iron-iconset-svg

### DIFF
--- a/components/d2l-organization-updates/OrganizationUpdatesMixin.js
+++ b/components/d2l-organization-updates/OrganizationUpdatesMixin.js
@@ -14,14 +14,14 @@ const OrganizationUpdatesImpl = (superClass) => class extends mixinBehaviors([D2
 					key: 'unreadAssignmentFeedback',
 					presentationLink: 'ShowDropboxUnreadFeedback',
 					toolTip: 'unreadAssignmentFeedback',
-					icon: 'd2l-tier1:assignments',
+					icon: 'd2l-tier1:d2l-icon-assignments',
 					order: 1
 				},
 				UnreadAssignmentSubmissions: {
 					key: 'unreadAssignmentFeedback',
 					presentationLink: 'ShowUnreadDropboxSubmissions',
 					toolTip: 'unreadAssignmentSubmissions',
-					icon: 'd2l-tier1:assignments',
+					icon: 'd2l-tier1:d2l-icon-assignments',
 					order: 1
 				},
 				UnattemptedQuizzes: {
@@ -42,14 +42,14 @@ const OrganizationUpdatesImpl = (superClass) => class extends mixinBehaviors([D2
 					key: 'unreadDiscussionFeedback',
 					presentationLink: 'ShowUnreadDiscussionMessages',
 					toolTip: 'unreadDiscussions',
-					icon: 'd2l-tier1:comment-hollow',
+					icon: 'd2l-tier1:d2l-icon-comment-hollow',
 					order: 2
 				},
 				UnapprovedDiscussions: {
 					key: 'unreadDiscussionFeedback',
 					presentationLink: 'ShowUnreadDiscussionMessages',
 					toolTip: 'unapprovedDiscussions',
-					icon: 'd2l-tier1:comment-hollow',
+					icon: 'd2l-tier1:d2l-icon-comment-hollow',
 					order: 2
 				}
 			}
@@ -155,4 +155,3 @@ const OrganizationUpdatesImpl = (superClass) => class extends mixinBehaviors([D2
 };
 
 export const OrganizationUpdatesMixin = dedupingMixin(OrganizationUpdatesImpl);
-

--- a/components/d2l-organization-updates/d2l-organization-updates.js
+++ b/components/d2l-organization-updates/d2l-organization-updates.js
@@ -9,7 +9,8 @@ Polymer-based web component for a organization updates.
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { OrganizationEntity } from 'siren-sdk/src/organizations/OrganizationEntity.js';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
-import 'd2l-icons/d2l-icon.js';
+import '@polymer/iron-icon/iron-icon.js';
+import 'd2l-colors/d2l-colors.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-offscreen/d2l-offscreen.js';
 import { OrganizationUpdatesMixin } from './OrganizationUpdatesMixin.js';
@@ -91,10 +92,11 @@ class OrganizationUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerEl
 				:host(:dir(rtl)) .organization-updates-container ~ * {
 					margin: 0 1.95rem 0 0;
 				}
-				d2l-icon {
-					--d2l-icon-width: var(--d2l-organization-updates-size, 18px);
-					--d2l-icon-height: var(--d2l-organization-updates-size, 18px);
+				iron-icon {
+					fill: var(--d2l-color-ferrite);
+					height: var(--d2l-organization-updates-size, 18px);
 					vertical-align: top;
+					width: var(--d2l-organization-updates-size, 18px);
 				}
 				.update-text-box {
 					border: 2px solid var(--d2l-color-carnelian);
@@ -130,7 +132,7 @@ class OrganizationUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerEl
 				.container[disabled] .update-text-box {
 					display: none;
 				}
-				.container[disabled] d2l-icon {
+				.container[disabled] iron-icon {
 					color: var(--d2l-color-mica);
 				}
 				.icon-tooltip {
@@ -156,7 +158,7 @@ class OrganizationUpdates extends OrganizationUpdatesMixin(EntityMixin(PolymerEl
 				<template is="dom-if" if="[[item.icon]]">
 					<span class="organization-updates-container" disabled$="[[item.isDisabled]]" id="[[item.key]]">
 						<a href="[[item.link]]">
-							<d2l-icon icon="[[item.icon]]"></d2l-icon>
+							<iron-icon icon="[[item.icon]]"></iron-icon>
 						</a>
 						<span class="update-text-box-icon update-text-box">
 							<div class="update-text-icon" aria-hidden="true">[[item.updateCount]]</div>

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
   "dependencies": {
     "@brightspace-ui/core": "^0.2.1",
     "@polymer/polymer": "^3.0.0",
+    "@polymer/iron-icon": "^3.0.1",
+    "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-course-image": "Brightspace/course-image#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",


### PR DESCRIPTION
This is just a temporary change.

Background: we don't want to support `iron-iconset-svg`s with the Lit version of icon. I will be adding support to Lit icon for custom SVGs like this place is using, but it will first have to upgrade to Lit and then switch over.

I'm also going to reach out to Bob/Sarah separately and see if using a custom icon is even necessary here.