### PR TITLE
cache and animate organization tabs

### DIFF
--- a/components/d2l-organization-consortium/build/lang/ar.js
+++ b/components/d2l-organization-consortium/build/lang/ar.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangArImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.ar = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangAr = dedupingMixin(LangArImpl);

--- a/components/d2l-organization-consortium/build/lang/da-dk.js
+++ b/components/d2l-organization-consortium/build/lang/da-dk.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangDadkImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.dadk = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangDadk = dedupingMixin(LangDadkImpl);

--- a/components/d2l-organization-consortium/build/lang/de.js
+++ b/components/d2l-organization-consortium/build/lang/de.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangDeImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.de = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangDe = dedupingMixin(LangDeImpl);

--- a/components/d2l-organization-consortium/build/lang/en.js
+++ b/components/d2l-organization-consortium/build/lang/en.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangEnImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.en = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangEn = dedupingMixin(LangEnImpl);

--- a/components/d2l-organization-consortium/build/lang/es.js
+++ b/components/d2l-organization-consortium/build/lang/es.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangEsImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.es = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangEs = dedupingMixin(LangEsImpl);

--- a/components/d2l-organization-consortium/build/lang/fi.js
+++ b/components/d2l-organization-consortium/build/lang/fi.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangFiImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.fi = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangFi = dedupingMixin(LangFiImpl);

--- a/components/d2l-organization-consortium/build/lang/fr-fr.js
+++ b/components/d2l-organization-consortium/build/lang/fr-fr.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangFrfrImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.frfr = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangFrfr = dedupingMixin(LangFrfrImpl);

--- a/components/d2l-organization-consortium/build/lang/fr.js
+++ b/components/d2l-organization-consortium/build/lang/fr.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangFrImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.fr = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangFr = dedupingMixin(LangFrImpl);

--- a/components/d2l-organization-consortium/build/lang/ja.js
+++ b/components/d2l-organization-consortium/build/lang/ja.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangJaImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.ja = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangJa = dedupingMixin(LangJaImpl);

--- a/components/d2l-organization-consortium/build/lang/ko.js
+++ b/components/d2l-organization-consortium/build/lang/ko.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangKoImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.ko = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangKo = dedupingMixin(LangKoImpl);

--- a/components/d2l-organization-consortium/build/lang/nl.js
+++ b/components/d2l-organization-consortium/build/lang/nl.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangNlImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.nl = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangNl = dedupingMixin(LangNlImpl);

--- a/components/d2l-organization-consortium/build/lang/pt.js
+++ b/components/d2l-organization-consortium/build/lang/pt.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangPtImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.pt = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangPt = dedupingMixin(LangPtImpl);

--- a/components/d2l-organization-consortium/build/lang/sv.js
+++ b/components/d2l-organization-consortium/build/lang/sv.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangSvImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.sv = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangSv = dedupingMixin(LangSvImpl);

--- a/components/d2l-organization-consortium/build/lang/tr.js
+++ b/components/d2l-organization-consortium/build/lang/tr.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangTrImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.tr = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangTr = dedupingMixin(LangTrImpl);

--- a/components/d2l-organization-consortium/build/lang/zh-tw.js
+++ b/components/d2l-organization-consortium/build/lang/zh-tw.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangZhtwImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.zhtw = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangZhtw = dedupingMixin(LangZhtwImpl);

--- a/components/d2l-organization-consortium/build/lang/zh.js
+++ b/components/d2l-organization-consortium/build/lang/zh.js
@@ -1,0 +1,15 @@
+'use strict';
+
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+
+/* @polymerMixin */
+const LangZhImpl = (superClass) => class extends superClass {
+	constructor() {
+		super();
+		this.zh = {
+			'loading': 'Loading'
+		};
+	}
+};
+
+export const LangZh = dedupingMixin(LangZhImpl);

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -16,12 +16,13 @@ import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/Consor
 import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { updateEntity } from 'siren-sdk/src/es6/EntityFactory.js';
+import { OrganizationConsortiumLocalize } from './organization-consortium-localize.js';
 
 /**
  * @customElement
  * @polymer
  */
-class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
+class OrganizationConsortiumTabs extends  EntityMixin(OrganizationConsortiumLocalize(PolymerElement)) {
 
 	static get is() { return 'd2l-organization-consortium-tabs'; }
 
@@ -124,7 +125,6 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				border-bottom: none;
 				z-index: 1;
 			}
-
 			.d2l-consortium-tab-growIn {
 				max-height: 1.5rem;
 				transform-origin: top;
@@ -144,7 +144,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]"></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">
-							<div class="d2l-consortium-tab-content" title="Loading" aria-label="Loading">...</div>
+							<div class="d2l-consortium-tab-content" title$="[[localize('loading')]]" aria-label$="[[localize('loading')]]">...</div>
 					</template>
 					</div>
 				</div>
@@ -156,7 +156,6 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 	constructor() {
 		super();
 		this._setEntityType(ConsortiumRootEntity);
-
 	}
 	getCacheKey() {
 		return `consortium-tabs-${this.token}`;
@@ -245,7 +244,6 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 						this.set(`_organizations.${key}.unread`, unread);
 						this._trySetItemSessionStorage(this.getCacheKey(), JSON.stringify(Object.assign({}, this._cache, this._organizations)));
 					});
-
 				});
 
 			});

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -9,7 +9,6 @@ import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '../d2l-organization-behavior.js';
 import 'd2l-navigation/d2l-navigation-notification-icon.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
-import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import { ConsortiumRootEntity } from 'siren-sdk/src/consortium/ConsortiumRootEntity.js';
 import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/ConsortiumTokenCollectionEntity.js';
@@ -22,7 +21,7 @@ import { OrganizationConsortiumLocalize } from './organization-consortium-locali
  * @customElement
  * @polymer
  */
-class OrganizationConsortiumTabs extends  EntityMixin(OrganizationConsortiumLocalize(PolymerElement)) {
+class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocalize(PolymerElement)) {
 
 	static get is() { return 'd2l-organization-consortium-tabs'; }
 

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -11,13 +11,14 @@ import 'd2l-navigation/d2l-navigation-notification-icon.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
+import 'd2l-loading-spinner/d2l-loading-spinner.js';
 import { ConsortiumRootEntity } from 'siren-sdk/src/consortium/ConsortiumRootEntity.js';
 import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/ConsortiumTokenCollectionEntity.js';
 import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { updateEntity } from 'siren-sdk/src/es6/EntityFactory.js';
 
-/**
+/**z
  * @customElement
  * @polymer
  */
@@ -41,9 +42,16 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				reflectToAttribute: true,
 				value: 2
 			},
+			_cache: {
+				type:Object
+			},
+
+			_shouldRender: {
+				type: Boolean,
+				value: false
+			},
 			_organizations: {
-				type: Object,
-				value: {}
+				type: Object
 			},
 			_parsedOrganizations: {
 				type: Array,
@@ -69,7 +77,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 	static get template() {
 		return html`
 		<style include="d2l-typography-shared-styles">
-			.d2l-consortium-tab a {
+			.d2l-consortium-tab-content {
 				@apply --d2l-body-small-text;
 				color: white;
 				display: inline-block;
@@ -91,12 +99,14 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 			[selected] .d2l-consortium-tab {
 				background: white;
 			}
-			[selected] .d2l-consortium-tab > a {
+			[selected] .d2l-consortium-tab > .d2l-consortium-tab-content {
 				color: var(--d2l-color-ferrite);
 			}
 			.d2l-consortium-tab-box {
 				display: flex;
 				flex-wrap: nowrap;
+				max-height:0;
+				overflow: hidden;
 			}
 			.d2l-consortium-tab-box :not(:first-child) {
 				margin-left: -1px;
@@ -115,14 +125,30 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				border-bottom: none;
 				z-index: 1;
 			}
+			.d2l-tab-container d2l-loading-spinner {
+				vertical-align: middle;
+			}
+			.d2l-consortium-tab-growIn {
+				max-height: 1.5rem;
+				transform-origin: top;
+				transition: max-height 500ms ease-in;
+			}
+			.d2l-consortium-tab-showTabs {
+				max-height: 1.5rem;
+			}
 
 		</style>
-		<div class="d2l-consortium-tab-box">
-			<template items="[[_parsedOrganizations]]" is="dom-repeat" sort="_sortOrder">
+		<div class$="d2l-consortium-tab-box [[_tabBoxClasses(_shouldRender, _cache)]]">
+			<template items="[[_parsedOrganizations]]" is="dom-repeat" sort="_sortOrder" >
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<div class="d2l-consortium-tab" id$="[[item.id]]" >
-						<a href="[[item.href]]" aria-label$="[[item.fullName]]">[[item.name]]</a>
+					<template is="dom-if" if="[[!item.loading]]">
+						<a href="[[item.href]]" class="d2l-consortium-tab-content " aria-label$="[[item.fullName]]">[[item.name]]</a>
 						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]"></d2l-navigation-notification-icon>
+					</template>
+					<template is="dom-if" if="[[item.loading]]">
+							<d2l-loading-spinner size="16"></d2l-loading-spinner>
+					</template>
 					</div>
 				</div>
 				<d2l-tooltip class="consortium-tab-tooltip" for="[[item.id]]" position="bottom">
@@ -136,11 +162,15 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 	constructor() {
 		super();
 		this._setEntityType(ConsortiumRootEntity);
-	}
 
+	}
+	getCacheKey() {
+		return `consortium-tabs-${this.token}`;
+	}
 	connectedCallback() {
 		super.connectedCallback();
 		this._intervalId = window.setInterval(this.updateAlerts.bind(this), this.pollIntervalInSeconds * 1000);
+		this._cache = this._tryGetItemSessionStorage(this.getCacheKey());
 	}
 
 	disconnectedCallback() {
@@ -148,7 +178,6 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 		window.clearInterval(this._intervalId);
 		dispose(this.__tokenCollection);
 	}
-
 	updateAlerts() {
 		for (var key in this._alertTokensMap) {
 			if (this._alertTokensMap.hasOwnProperty(key)) {
@@ -156,11 +185,33 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 			}
 		}
 	}
-
+	_tabBoxClasses(_shouldRender, _hasCache) {
+		const classes = [];
+		if (_hasCache) {
+			classes.push('d2l-consortium-tab-showTabs');
+		} else if (_shouldRender) {
+			classes.push('d2l-consortium-tab-growIn');
+		}
+		return classes.join(' ');
+	}
 	_isSelected(item) {
 		return this.selected === item.tenant;
 	}
-
+	_tryGetItemSessionStorage(itemName) {
+		try {
+			return JSON.parse(sessionStorage.getItem(itemName));
+		} catch (_) {
+			//noop if session storage isn't available or has bad data
+			return;
+		}
+	}
+	_trySetItemSessionStorage(itemName, value) {
+		try {
+			sessionStorage.setItem(itemName, value);
+		} catch (_) {
+			//noop we don't want to blow up if we exceed a quota or are in safari private browsing mode
+		}
+	}
 	_sortOrder(item1, item2) {
 		return item1.name.localeCompare(item2.name);
 	}
@@ -177,23 +228,30 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 	_onConsortiumChange(consotriumTokenCollection) {
 		this.__tokenCollection = consotriumTokenCollection;
 		consotriumTokenCollection.consortiumTokenEntities((consortiumEntity) => {
+			const key = consortiumEntity.consortiumTenant();
+			this._shouldRender = true;
+			if (!this._cache || !this._cache[key]) {
+				this.set(`_organizations.${key}`, {name:key, loading:true});
+			}
 			consortiumEntity.rootOrganizationEntity((rootEntity) => {
 				rootEntity.organization((orgEntity) => {
-					const key = consortiumEntity.consortiumTenant();
 					this.set(`_organizations.${key}`, {
 						name: orgEntity.name(),
 						code: orgEntity.code(),
-						href: orgEntity.fullyQualifiedOrganizationHomepageUrl()
+						href: orgEntity.fullyQualifiedOrganizationHomepageUrl(),
+						loading: false
 					});
 
 					if (orgEntity.alertsUrl() && consortiumEntity.consortiumToken()) {
 						this._alertTokensMap[orgEntity.alertsUrl()] = consortiumEntity.consortiumToken();
 					}
-
+					this._trySetItemSessionStorage(this.getCacheKey(), JSON.stringify(Object.assign({}, this._cache, this._organizations)));
 					orgEntity.onAlertsChange(alertsEntity => {
 						const unread = alertsEntity.hasUnread();
 						this.set(`_organizations.${key}.unread`, unread);
+						this._trySetItemSessionStorage(this.getCacheKey(), JSON.stringify(Object.assign({}, this._cache, this._organizations)));
 					});
+
 				});
 			});
 		});
@@ -205,7 +263,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 	}
 
 	_computeParsedOrganizations() {
-		const currentOrganizations = this._organizations;
+		const currentOrganizations = Object.assign({}, this._cache, this._organizations);
 		const orgs = Object.keys(currentOrganizations).map(function(key) {
 			const org = {
 				id: D2L.Id.getUniqueId(),
@@ -214,6 +272,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				href: currentOrganizations[key].href,
 				hasNotification: currentOrganizations[key].unread,
 				tenant: key,
+				loading: currentOrganizations[key].loading
 			};
 			return org;
 		});

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -11,7 +11,6 @@ import 'd2l-navigation/d2l-navigation-notification-icon.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import 'd2l-loading-spinner/d2l-loading-spinner.js';
 import { ConsortiumRootEntity } from 'siren-sdk/src/consortium/ConsortiumRootEntity.js';
 import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/ConsortiumTokenCollectionEntity.js';
 import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
@@ -125,9 +124,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				border-bottom: none;
 				z-index: 1;
 			}
-			.d2l-tab-container d2l-loading-spinner {
-				vertical-align: middle;
-			}
+
 			.d2l-consortium-tab-growIn {
 				max-height: 1.5rem;
 				transform-origin: top;
@@ -143,19 +140,14 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<div class="d2l-consortium-tab" id$="[[item.id]]" >
 					<template is="dom-if" if="[[!item.loading]]">
-						<a href="[[item.href]]" class="d2l-consortium-tab-content " aria-label$="[[item.fullName]]">[[item.name]]</a>
+						<a href="[[item.href]]" class="d2l-consortium-tab-content " aria-label$="[[item.fullName]]" title$="[[item.fullName]]">[[item.name]]</a>
 						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]"></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">
-							<d2l-loading-spinner size="16"></d2l-loading-spinner>
+							<div class="d2l-consortium-tab-content" title="Loading" aria-label="Loading">...</div>
 					</template>
 					</div>
 				</div>
-				<template is="dom-if" if="[[item.loading]]">
-					<d2l-tooltip class="consortium-tab-tooltip" for="[[item.id]]" position="bottom">
-						[[item.fullName]]
-					</d2l-tooltip>
-				</template>
 			</template>
 		</div>
 		`;
@@ -255,6 +247,7 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 					});
 
 				});
+
 			});
 		});
 	}

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -18,7 +18,7 @@ import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
 import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { updateEntity } from 'siren-sdk/src/es6/EntityFactory.js';
 
-/**z
+/**
  * @customElement
  * @polymer
  */

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -151,9 +151,11 @@ class OrganizationConsortiumTabs extends EntityMixin(PolymerElement) {
 					</template>
 					</div>
 				</div>
-				<d2l-tooltip class="consortium-tab-tooltip" for="[[item.id]]" position="bottom">
-					[[item.fullName]]
-				</d2l-tooltip>
+				<template is="dom-if" if="[[item.loading]]">
+					<d2l-tooltip class="consortium-tab-tooltip" for="[[item.id]]" position="bottom">
+						[[item.fullName]]
+					</d2l-tooltip>
+				</template>
 			</template>
 		</div>
 		`;

--- a/components/d2l-organization-consortium/lang/ar.json
+++ b/components/d2l-organization-consortium/lang/ar.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/da-dk.json
+++ b/components/d2l-organization-consortium/lang/da-dk.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/de.json
+++ b/components/d2l-organization-consortium/lang/de.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/en.json
+++ b/components/d2l-organization-consortium/lang/en.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/es.json
+++ b/components/d2l-organization-consortium/lang/es.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/fi.json
+++ b/components/d2l-organization-consortium/lang/fi.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/fr-fr.json
+++ b/components/d2l-organization-consortium/lang/fr-fr.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/fr.json
+++ b/components/d2l-organization-consortium/lang/fr.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/ja.json
+++ b/components/d2l-organization-consortium/lang/ja.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/ko.json
+++ b/components/d2l-organization-consortium/lang/ko.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/nl.json
+++ b/components/d2l-organization-consortium/lang/nl.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/pt.json
+++ b/components/d2l-organization-consortium/lang/pt.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/sv.json
+++ b/components/d2l-organization-consortium/lang/sv.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/tr.json
+++ b/components/d2l-organization-consortium/lang/tr.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/zh-tw.json
+++ b/components/d2l-organization-consortium/lang/zh-tw.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/lang/zh.json
+++ b/components/d2l-organization-consortium/lang/zh.json
@@ -1,0 +1,6 @@
+{
+  "loading": {
+    "translation": "Loading",
+    "context": "Placeholder loading text until content is ready"
+  }
+}

--- a/components/d2l-organization-consortium/organization-consortium-localize.js
+++ b/components/d2l-organization-consortium/organization-consortium-localize.js
@@ -1,0 +1,77 @@
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import 'd2l-localize-behavior/d2l-localize-behavior.js';
+import {LangAr} from './build/lang/ar.js';
+import {LangDe} from './build/lang/de.js';
+import {LangEn} from './build/lang/en.js';
+import {LangEs} from './build/lang/es.js';
+import {LangFi} from './build/lang/fi.js';
+import {LangFr} from './build/lang/fr.js';
+import {LangJa} from './build/lang/ja.js';
+import {LangKo} from './build/lang/ko.js';
+import {LangNl} from './build/lang/nl.js';
+import {LangPt} from './build/lang/pt.js';
+import {LangSv} from './build/lang/sv.js';
+import {LangTr} from './build/lang/tr.js';
+import {LangZhtw} from './build/lang/zh-tw.js';
+import {LangZh} from './build/lang/zh.js';
+
+/* @polymerMixin */
+const OrganizationConsortiumLocalizeImpl = (superClass) => {
+	const langMixins = [
+		LangAr,
+		LangDe,
+		LangEn,
+		LangEs,
+		LangFi,
+		LangFr,
+		LangJa,
+		LangKo,
+		LangNl,
+		LangPt,
+		LangSv,
+		LangTr,
+		LangZhtw,
+		LangZh
+	];
+	let mixinLang = mixinBehaviors([D2L.PolymerBehaviors.LocalizeBehavior], superClass);
+	for (const langMixin of langMixins) {
+		mixinLang = langMixin(mixinLang);
+	}
+	return class extends mixinLang {
+		static get properties() {
+			return {
+				locale: {
+					type: String,
+					value: function() {
+						return document.documentElement.lang
+							|| document.documentElement.getAttribute('data-lang-default')
+							|| 'en-us';
+					}
+				}
+			};
+		}
+
+		constructor() {
+			super();
+			this.resources = {
+				'en': this.en,
+				'ar': this.ar,
+				'de': this.de,
+				'es': this.es,
+				'fi': this.fi,
+				'fr': this.fr,
+				'ja': this.ja,
+				'ko': this.ko,
+				'nl': this.nl,
+				'pt': this.pt,
+				'sv': this.sv,
+				'tr': this.tr,
+				'zh': this.zh,
+				'zh-tw': this.zhtw
+			};
+		}
+	};
+};
+
+export const OrganizationConsortiumLocalize = dedupingMixin(OrganizationConsortiumLocalizeImpl);

--- a/demo/d2l-organization-consortium/d2l-organization-consortium.html
+++ b/demo/d2l-organization-consortium/d2l-organization-consortium.html
@@ -22,12 +22,13 @@
 			// override window.fetch, but defer if we haven't provided an explicit mock
 			window.fetch = 	(input, init) => {
 				const whatToFetch = {
-					'http://localhost:8081/consortium.json': {method: 'POST', response: consortium},
+					'/consortium.json': {method: 'POST', response: consortium},
 				};
-				if (whatToFetch[input.url] && whatToFetch[input.url].method === input.method) {
+				const url = new URL(input.url);
+				if (whatToFetch[url.pathname] && whatToFetch[url.pathname].method === input.method) {
 					return Promise.resolve({
 						ok: true,
-						json: () => { return Promise.resolve(whatToFetch[input.url].response); }
+						json: () => { return Promise.resolve(whatToFetch[url.pathname].response); }
 					});
 				} else {
 					//if we haven't explicity coded a mock, let's leave it be
@@ -59,10 +60,17 @@
 						}
 						.demo {
 							align-items: center;
-							background-color: var(--d2l-color-carnelian);
+							background-image: linear-gradient(to bottom, #f6f7f8, #f6f7f8), linear-gradient(to top, #ffffff, #f9fafb);
 							padding: 50px;
 							height: 100px;
+							overflow: hidden;
 						}
+						.nav-band {
+							background-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
+							display: block;
+							min-height: 4px;
+						}
+
 					</style>
 				</custom-style>
 			`;
@@ -75,7 +83,20 @@
 			<demo-snippet>
 				<template>
 					<div class="demo">
-						<d2l-organization-consortium-tabs id="tabs" href="../data/consortium/consortium-root.json"></d2l-organization-consortium-tabs>
+						<div class="nav-band">
+							<d2l-organization-consortium-tabs id="tabs" href="../data/consortium/consortium-root.json" token="faketoken"></d2l-organization-consortium-tabs>
+						</div>
+						<p>
+Bacon ipsum dolor amet turkey swine picanha, tail cow ham drumstick. Ball tip pork bacon, doner t-bone venison beef porchetta fatback capicola turkey ham pork belly andouille. Frankfurter pork belly turducken short ribs, buffalo boudin meatball fatback flank sausage shoulder spare ribs. Burgdoggen alcatra kielbasa, spare ribs sausage t-bone shoulder kevin doner pork shank pork chop bresaola meatloaf. Buffalo beef ribs hamburger alcatra venison strip steak flank, drumstick pig turkey pork loin ham beef.
+
+Tail short ribs drumstick andouille swine beef biltong brisket prosciutto picanha filet mignon. Burgdoggen drumstick swine brisket pastrami. Swine pork sirloin, chuck beef meatloaf drumstick porchetta. Fatback picanha ham hock beef ribs flank capicola burgdoggen short ribs. Tri-tip kielbasa frankfurter fatback brisket, shoulder bresaola short loin. Pork loin burgdoggen turkey bresaola, ball tip pork chop meatball tail ground round tri-tip pork ham hock.
+
+Short ribs chuck shankle hamburger pastrami. Biltong meatloaf t-bone, jerky fatback short ribs kielbasa bacon tenderloin short loin alcatra chicken cupim filet mignon. Biltong doner tail pig, andouille ham hock shank shoulder cow turkey meatball short loin jerky. Beef ribs turducken bacon pastrami spare ribs tri-tip. Alcatra kevin corned beef fatback, turkey pig chicken hamburger tongue tenderloin pork.
+
+Kielbasa pancetta doner bacon tongue cow. Pastrami tenderloin flank, drumstick corned beef leberkas shoulder venison andouille beef short loin hamburger ball tip jerky. Jerky prosciutto doner meatloaf, chuck buffalo chicken kevin ground round pig frankfurter cow boudin strip steak. Doner chuck flank sausage beef ribs beef, pork chop bresaola pig tenderloin porchetta spare ribs. Tri-tip shank chicken jowl leberkas kevin, biltong salami tenderloin kielbasa doner pastrami. Kevin swine hamburger, pork chop bresaola ribeye kielbasa buffalo spare ribs ball tip short ribs ground round.
+
+Ground round meatball spare ribs filet mignon corned beef shankle alcatra tongue burgdoggen ball tip ham flank. Burgdoggen ground round pastrami pork turkey venison pork belly andouille tongue hamburger. Shankle ham hock ball tip meatloaf short loin t-bone pork belly. T-bone capicola tongue swine pancetta brisket.
+						</p>
 					</div>
 				</template>
 			</demo-snippet>

--- a/demo/data/consortium/organization1-consortium.json
+++ b/demo/data/consortium/organization1-consortium.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "name": "Consortium 1",
-    "code": "c1",
+    "code": "z1",
     "startDate": null,
     "endDate": null,
     "isActive": true,

--- a/demo/data/consortium/organization2-consortium.json
+++ b/demo/data/consortium/organization2-consortium.json
@@ -1,7 +1,7 @@
 {
   "properties": {
     "name": "Consortium 2",
-    "code": "c1",
+    "code": "z1",
     "startDate": null,
     "endDate": null,
     "isActive": true,

--- a/demo/data/consortium/organization4-consortium.json
+++ b/demo/data/consortium/organization4-consortium.json
@@ -1,6 +1,6 @@
 {
   "properties": {
-    "name": "Spicy jalapeno bacon ipsum dolor amet cupim tri-tip pastrami filet mignon short ribs, jerky drumstick ribeye kielbasa",
+    "name": "bSpicy jalapeno bacon ipsum dolor amet cupim tri-tip pastrami filet mignon short ribs, jerky drumstick ribeye kielbasa",
     "code": null,
     "startDate": null,
     "endDate": null,

--- a/organizations.serge.json
+++ b/organizations.serge.json
@@ -74,5 +74,31 @@
     "pr_reviewers": [
       "m6jones"
     ]
+  },
+  {
+    "name": "consortium",
+    "source_dir": "components/d2l-organization-consortium/lang",
+    "output_file_path": "components/d2l-organization-consortium/lang/%LANG%.json",
+    "parser_plugin": {
+      "plugin": "parse_d2l_fra"
+    },
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ],
+    "pr_reviewers": [
+      "ctwomey1"
+    ]
   }
 ]

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "d2l-course-image": "Brightspace/course-image#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
-    "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "d2l-course-image": "Brightspace/course-image#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
+    "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-navigation": "BrightspaceUI/navigation#semver:^4",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -5,6 +5,7 @@ describe('d2l-organization-consortium-tabs', () => {
 	var sandbox;
 	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
Demo (with exaggerated load times)
![pOepqjLAir](https://user-images.githubusercontent.com/1779270/64188790-a6984c00-ce38-11e9-8be7-8982c487a3c9.gif)

This is a first stab at reducing page jankiness when consortium tabs are on.  On first load we slowly grow the height of the element to reveal the tabs.  Each subsequent load of the page will be near instant as we are pulling the first render from our session storage.  To ensure we aren't missing content I still reach out to the apis and update in the background. 

For some added smoothness, I added the loading spinner in a bit of a tab skeleton so tabs aren't popping in randomly