### PR TITLE
US109311 - Design Tweaks

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -126,6 +126,8 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				display: flex;
 				flex-wrap: nowrap;
 				max-height: 0;
+				overflow-x: unset;
+				overflow-y: hidden;
 			}
 			.d2l-consortium-tab-box :not(:first-child) {
 				margin-left: -1px;

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -112,7 +112,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 			.d2l-consortium-tab {
 				background: rgba(0, 0, 0, .54);
 				border-bottom: none;
-				border-radius: 4px 4px 0 0;
+				border-radius: 5px 5px 0 0;
 				max-width: 5.5rem;
 				padding: 0 0.6rem;
 			}
@@ -125,19 +125,18 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 			.d2l-consortium-tab-box {
 				display: flex;
 				flex-wrap: nowrap;
-				max-height:0;
-				overflow: hidden;
+				max-height: 0;
 			}
 			.d2l-consortium-tab-box :not(:first-child) {
 				margin-left: -1px;
 			}
 			.d2l-tab-container {
 				border: rgba(255, 255, 255, .30) solid 1px;
-				border-radius: 5px 5px 0 0;
+				border-radius: 6px 6px 0 0;
 				border-bottom: none;
 				display: inline-block;
-				line-height: 1rem;
-				margin: 0.2rem 0 0 0;
+				line-height: 1.3rem;
+				margin: 4px 0 0 0;
 				position: relative;
 			}
 			.d2l-tab-container[selected] {

--- a/demo/d2l-organization-consortium/d2l-organization-consortium.html
+++ b/demo/d2l-organization-consortium/d2l-organization-consortium.html
@@ -16,6 +16,7 @@
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';
 			import 'd2l-typography/d2l-typography.js';
+			import 'd2l-navigation/d2l-navigation-band.js';
 			import '../../components/d2l-organization-consortium/d2l-organization-consortium-tabs.js';
 			import {consortium} from '../data/consortium/consortium.js';
 			import {consortiumError} from '../data/consortium/consortium-with-error.js';
@@ -48,31 +49,15 @@
 						html {
 							font-size: 20px;
 						}
-						.fixed-size {
-							display:flex;
-							align-items: stretch;
-							flex-direction: column;
-							min-width: 0;
-							max-width: 900px;
-							flex-shrink: 1;
-							margin:auto;
-						}
 						h3 {
 							text-align: center;
 						}
 						.demo {
-							align-items: center;
 							background-image: linear-gradient(to bottom, #f6f7f8, #f6f7f8), linear-gradient(to top, #ffffff, #f9fafb);
 							padding: 50px;
 							height: 100px;
 							overflow: hidden;
 						}
-						.nav-band {
-							background-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
-							display: block;
-							min-height: 4px;
-						}
-
 					</style>
 				</custom-style>
 			`;
@@ -80,14 +65,14 @@
 		</script>
 	</head>
 	<body class="d2l-typography">
-		<div class="vertical-section-container fixed-size">
+		<div class="vertical-section-container">
 			<h3>Basic d2l-organization-consortium demo</h3>
 			<demo-snippet>
 				<template>
 					<div class="demo">
-						<div class="nav-band">
+						<d2l-navigation-band>
 							<d2l-organization-consortium-tabs id="tabs" href="../data/consortium/consortium-root.json" token="faketoken"></d2l-organization-consortium-tabs>
-						</div>
+						</d2l-navigation-band>
 						<p>
 Bacon ipsum dolor amet turkey swine picanha, tail cow ham drumstick. Ball tip pork bacon, doner t-bone venison beef porchetta fatback capicola turkey ham pork belly andouille. Frankfurter pork belly turducken short ribs, buffalo boudin meatball fatback flank sausage shoulder spare ribs. Burgdoggen alcatra kielbasa, spare ribs sausage t-bone shoulder kevin doner pork shank pork chop bresaola meatloaf. Buffalo beef ribs hamburger alcatra venison strip steak flank, drumstick pig turkey pork loin ham beef.
 
@@ -103,14 +88,14 @@ Ground round meatball spare ribs filet mignon corned beef shankle alcatra tongue
 				</template>
 			</demo-snippet>
 		</div>
-		<div class="vertical-section-container fixed-size">
+		<div class="vertical-section-container">
 			<h3>Consortium with an error present</h3>
 			<demo-snippet>
 				<template>
 					<div class="demo">
-						<div class="nav-band">
+						<d2l-navigation-band>
 							<d2l-organization-consortium-tabs id="tabs" href="../data/consortium/consortium-root-with-error.json" token="faketoken2"></d2l-organization-consortium-tabs>
-						</div>
+						</d2l-navigation-band>
 						<p>
 Bacon ipsum dolor amet turkey swine picanha, tail cow ham drumstick. Ball tip pork bacon, doner t-bone venison beef porchetta fatback capicola turkey ham pork belly andouille. Frankfurter pork belly turducken short ribs, buffalo boudin meatball fatback flank sausage shoulder spare ribs. Burgdoggen alcatra kielbasa, spare ribs sausage t-bone shoulder kevin doner pork shank pork chop bresaola meatloaf. Buffalo beef ribs hamburger alcatra venison strip steak flank, drumstick pig turkey pork loin ham beef.
 


### PR DESCRIPTION
- Remove `overflow: hidden` to prepare for the scrollbar work
- Small design adjustments requested by Jeff, we're making the tabs a bit bigger
- Use `d2l-navigation-band` in the demo