### PR TITLE
DE35598 - Add screenreader text to indicate the presence of the notification dot

### DIFF
--- a/components/d2l-organization-consortium/build/lang/ar.js
+++ b/components/d2l-organization-consortium/build/lang/ar.js
@@ -9,7 +9,8 @@ const LangArImpl = (superClass) => class extends superClass {
 		this.ar = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - لديك تنبيهات جديدة'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/ar.js
+++ b/components/d2l-organization-consortium/build/lang/ar.js
@@ -7,9 +7,9 @@ const LangArImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ar = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'يتم الآن التحميل',
 			'newNotifications': '{name} - لديك تنبيهات جديدة'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/da-dk.js
+++ b/components/d2l-organization-consortium/build/lang/da-dk.js
@@ -9,7 +9,8 @@ const LangDadkImpl = (superClass) => class extends superClass {
 		this.dadk = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Du har nye notifikationer'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/de.js
+++ b/components/d2l-organization-consortium/build/lang/de.js
@@ -7,9 +7,9 @@ const LangDeImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.de = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Wird geladen',
 			'newNotifications': '{name} – Sie haben neue Benachrichtigungen.'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/de.js
+++ b/components/d2l-organization-consortium/build/lang/de.js
@@ -9,7 +9,8 @@ const LangDeImpl = (superClass) => class extends superClass {
 		this.de = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} – Sie haben neue Benachrichtigungen.'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/en.js
+++ b/components/d2l-organization-consortium/build/lang/en.js
@@ -9,7 +9,8 @@ const LangEnImpl = (superClass) => class extends superClass {
 		this.en = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - You have new alerts'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/es.js
+++ b/components/d2l-organization-consortium/build/lang/es.js
@@ -9,7 +9,8 @@ const LangEsImpl = (superClass) => class extends superClass {
 		this.es = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Tiene nuevas alertas'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/es.js
+++ b/components/d2l-organization-consortium/build/lang/es.js
@@ -7,9 +7,9 @@ const LangEsImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.es = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Cargando',
 			'newNotifications': '{name} - Tiene nuevas alertas'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/fi.js
+++ b/components/d2l-organization-consortium/build/lang/fi.js
@@ -9,7 +9,8 @@ const LangFiImpl = (superClass) => class extends superClass {
 		this.fi = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - You have new alerts'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/fr-fr.js
+++ b/components/d2l-organization-consortium/build/lang/fr-fr.js
@@ -9,7 +9,8 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 		this.frfr = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Vous avez de nouvelles alertes'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/fr.js
+++ b/components/d2l-organization-consortium/build/lang/fr.js
@@ -9,7 +9,8 @@ const LangFrImpl = (superClass) => class extends superClass {
 		this.fr = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Vous avez de nouvelles alertes'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/fr.js
+++ b/components/d2l-organization-consortium/build/lang/fr.js
@@ -7,9 +7,9 @@ const LangFrImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.fr = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Chargement',
 			'newNotifications': '{name} - Vous avez de nouvelles alertes'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/ja.js
+++ b/components/d2l-organization-consortium/build/lang/ja.js
@@ -7,9 +7,9 @@ const LangJaImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ja = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': '読み込み中',
 			'newNotifications': '{name} - 新しいお知らせがあります'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/ja.js
+++ b/components/d2l-organization-consortium/build/lang/ja.js
@@ -9,7 +9,8 @@ const LangJaImpl = (superClass) => class extends superClass {
 		this.ja = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - 新しいお知らせがあります'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/ko.js
+++ b/components/d2l-organization-consortium/build/lang/ko.js
@@ -9,7 +9,8 @@ const LangKoImpl = (superClass) => class extends superClass {
 		this.ko = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name}개 - 새로운 알림이 있습니다.'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/ko.js
+++ b/components/d2l-organization-consortium/build/lang/ko.js
@@ -7,9 +7,9 @@ const LangKoImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ko = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': '로드 중',
 			'newNotifications': '{name}개 - 새로운 알림이 있습니다.'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/nl.js
+++ b/components/d2l-organization-consortium/build/lang/nl.js
@@ -9,7 +9,8 @@ const LangNlImpl = (superClass) => class extends superClass {
 		this.nl = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - U hebt nieuwe waarschuwingen'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/nl.js
+++ b/components/d2l-organization-consortium/build/lang/nl.js
@@ -7,9 +7,9 @@ const LangNlImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.nl = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Laden',
 			'newNotifications': '{name} - U hebt nieuwe waarschuwingen'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/pt.js
+++ b/components/d2l-organization-consortium/build/lang/pt.js
@@ -7,9 +7,9 @@ const LangPtImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.pt = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Carregando',
 			'newNotifications': '{name} - Você tem novos alertas'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/pt.js
+++ b/components/d2l-organization-consortium/build/lang/pt.js
@@ -9,7 +9,8 @@ const LangPtImpl = (superClass) => class extends superClass {
 		this.pt = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Você tem novos alertas'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/sv.js
+++ b/components/d2l-organization-consortium/build/lang/sv.js
@@ -7,9 +7,9 @@ const LangSvImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.sv = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Laddar',
 			'newNotifications': '{name} – Du har nya varningar'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/sv.js
+++ b/components/d2l-organization-consortium/build/lang/sv.js
@@ -9,7 +9,8 @@ const LangSvImpl = (superClass) => class extends superClass {
 		this.sv = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} – Du har nya varningar'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/tr.js
+++ b/components/d2l-organization-consortium/build/lang/tr.js
@@ -7,9 +7,9 @@ const LangTrImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.tr = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': 'Yükleniyor',
 			'newNotifications': '{name} - Yeni uyarılarınız var'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/tr.js
+++ b/components/d2l-organization-consortium/build/lang/tr.js
@@ -9,7 +9,8 @@ const LangTrImpl = (superClass) => class extends superClass {
 		this.tr = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - Yeni uyarılarınız var'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/zh-tw.js
+++ b/components/d2l-organization-consortium/build/lang/zh-tw.js
@@ -9,7 +9,8 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 		this.zhtw = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - 您有新警示'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/build/lang/zh-tw.js
+++ b/components/d2l-organization-consortium/build/lang/zh-tw.js
@@ -7,9 +7,9 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.zhtw = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': '正在載入',
 			'newNotifications': '{name} - 您有新警示'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/zh.js
+++ b/components/d2l-organization-consortium/build/lang/zh.js
@@ -7,9 +7,9 @@ const LangZhImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.zh = {
-			'loading': 'Loading',
-			'errorShort': 'Oops',
 			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'errorShort': 'Oops',
+			'loading': '正在加载',
 			'newNotifications': '{name} - 您有新提示'
 		};
 	}

--- a/components/d2l-organization-consortium/build/lang/zh.js
+++ b/components/d2l-organization-consortium/build/lang/zh.js
@@ -9,7 +9,8 @@ const LangZhImpl = (superClass) => class extends superClass {
 		this.zh = {
 			'loading': 'Loading',
 			'errorShort': 'Oops',
-			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page'
+			'errorFull': 'Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page',
+			'newNotifications': '{name} - 您有新提示'
 		};
 	}
 };

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -177,7 +177,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<div class="d2l-consortium-tab" id$="[[item.id]]" >
 					<template is="dom-if" if="[[!item.loading]]">
-						<a href="[[item.href]]" class="d2l-consortium-tab-content" aria-label$="[[_getLinkLabel(item)]]">[[item.name]]</a>
+						<a href="[[item.href]]" class="d2l-consortium-tab-content" aria-label$="[[_getTabAriaLabel(item)]]">[[item.name]]</a>
 						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]" thin-border></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">
@@ -185,7 +185,6 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 					</template>
 					</div>
 				</div>
-
 
 				<d2l-tooltip class="consortium-tab-tooltip" for="[[item.id]]" delay="500" position="bottom">
 					[[_successfulTabToolTipText(item)]]
@@ -286,9 +285,9 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 		}
 	}
 
-	_onConsortiumChange(consotriumTokenCollection) {
-		this.__tokenCollection = consotriumTokenCollection;
-		consotriumTokenCollection.consortiumTokenEntities((consortiumEntity) => {
+	_onConsortiumChange(consortiumTokenCollection) {
+		this.__tokenCollection = consortiumTokenCollection;
+		consortiumTokenCollection.consortiumTokenEntities((consortiumEntity) => {
 			const key = consortiumEntity.consortiumTenant();
 			this._shouldRender = true;
 			if (!this._cache || !this._cache[key]) {
@@ -369,7 +368,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 	_successfulTabToolTipText(item) {
 		return item.loading ? this.localize('loading') : item.fullName;
 	}
-	_getLinkLabel(item) {
+	_getTabAriaLabel(item) {
 		return item.hasNotification ? this.localize('newNotifications', 'name', item.fullName) : item.fullName;
 	}
 	_hasErrors(errors) {

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -10,9 +10,8 @@ import '../d2l-organization-behavior.js';
 import 'd2l-navigation/d2l-navigation-notification-icon.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
 import 'd2l-tooltip/d2l-tooltip.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import { ConsortiumRootEntity } from 'siren-sdk/src/consortium/ConsortiumRootEntity.js';
 import { ConsortiumTokenCollectionEntity } from 'siren-sdk/src/consortium/ConsortiumTokenCollectionEntity.js';
 import { entityFactory, dispose } from 'siren-sdk/src/es6/EntityFactory';
@@ -178,7 +177,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<div class="d2l-consortium-tab" id$="[[item.id]]" >
 					<template is="dom-if" if="[[!item.loading]]">
-						<a href="[[item.href]]" class="d2l-consortium-tab-content" aria-label$="[[item.fullName]]">[[item.name]]</a>
+						<a href="[[item.href]]" class="d2l-consortium-tab-content" aria-label$="[[_getLinkLabel(item)]]">[[item.name]]</a>
 						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]" thin-border></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">
@@ -369,6 +368,9 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 	}
 	_successfulTabToolTipText(item) {
 		return item.loading ? this.localize('loading') : item.fullName;
+	}
+	_getLinkLabel(item) {
+		return item.hasNotification ? this.localize('newNotifications', 'name', item.fullName) : item.fullName;
 	}
 	_hasErrors(errors) {
 		return errors.length > 0;

--- a/components/d2l-organization-consortium/lang/ar.json
+++ b/components/d2l-organization-consortium/lang/ar.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - لديك تنبيهات جديدة",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/da-dk.json
+++ b/components/d2l-organization-consortium/lang/da-dk.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Du har nye notifikationer",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/de.json
+++ b/components/d2l-organization-consortium/lang/de.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} – Sie haben neue Benachrichtigungen.",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/en.json
+++ b/components/d2l-organization-consortium/lang/en.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - You have new alerts",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/es.json
+++ b/components/d2l-organization-consortium/lang/es.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Tiene nuevas alertas",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/fi.json
+++ b/components/d2l-organization-consortium/lang/fi.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - You have new alerts",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/fr-fr.json
+++ b/components/d2l-organization-consortium/lang/fr-fr.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Vous avez de nouvelles alertes",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/fr.json
+++ b/components/d2l-organization-consortium/lang/fr.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Vous avez de nouvelles alertes",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/ja.json
+++ b/components/d2l-organization-consortium/lang/ja.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - 新しいお知らせがあります",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/ko.json
+++ b/components/d2l-organization-consortium/lang/ko.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name}개 - 새로운 알림이 있습니다.",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/nl.json
+++ b/components/d2l-organization-consortium/lang/nl.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - U hebt nieuwe waarschuwingen",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/pt.json
+++ b/components/d2l-organization-consortium/lang/pt.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Você tem novos alertas",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/sv.json
+++ b/components/d2l-organization-consortium/lang/sv.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} – Du har nya varningar",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/tr.json
+++ b/components/d2l-organization-consortium/lang/tr.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - Yeni uyarılarınız var",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/zh-tw.json
+++ b/components/d2l-organization-consortium/lang/zh-tw.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - 您有新警示",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/components/d2l-organization-consortium/lang/zh.json
+++ b/components/d2l-organization-consortium/lang/zh.json
@@ -10,5 +10,9 @@
   "errorFull": {
     "translation": "Oops! We were unable to fetch information for {num} of your tabs. Try refreshing the page",
     "context": "Full error message if something went wrong.  With num indicating how many instances of the error"
+  },
+  "newNotifications": {
+    "translation": "{name} - 您有新提示",
+    "context": "If the notification dot is present, we wrap the organization name for the tab's link label"
   }
 }

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -186,7 +186,9 @@ describe('d2l-organization-consortium-tabs', function() {
 				const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
 				assert.equal(dots.length, 2);
 				assert.isFalse(dots[0].hasAttribute('hidden'));
+				assert.equal(tabs[0].getAttribute('aria-label'), 'Consortium 1 - You have new alerts');
 				assert.isTrue(dots[1].hasAttribute('hidden'));
+				assert.equal(tabs[1].getAttribute('aria-label'), 'Consortium 2');
 				const errorMessage = component.shadowRoot.querySelectorAll('div.d2l-consortium-tab-content > d2l-icon[icon="tier1:alert"]');
 				assert.equal(errorMessage.length, 0, 'Error tab should not be visible when no errors present');
 				done();


### PR DESCRIPTION
Instead of using `d2l-offscreen`, I'm wrapping the `aria-label` with this information so it's read out automatically when moving to the tab, rather than only when using the arrow keys.

Stole the langterm from https://search.d2l.dev/search?project=lms&full=lblNewNotifications&defs=&refs=&path=Navbars.xml&hist=&type=&si=full