### PR TITLE
US110536 - Add notification update event for the org tabs

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -148,6 +148,11 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				outline: none;
 				padding: 0 0.6rem;
 			}
+			@media (max-width: 767px) {
+				.d2l-consortium-tab {
+					padding: 0 0.5rem;
+				}
+			}
 			.d2l-consortium-tab:hover {
 				background-color: rgba(0, 0, 0, .70);
 			}

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -72,6 +72,10 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 					return {};
 				}
 			},
+			_hasNotifications: {
+				type: Boolean,
+				value: false
+			},
 			__tokenCollection: {
 				type: Object
 			},
@@ -84,7 +88,8 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 
 	static get observers() {
 		return [
-			'_onConsortiumRootChange(_entity)'
+			'_onConsortiumRootChange(_entity)',
+			'_checkNotifications(_parsedOrganizations.*)'
 		];
 	}
 
@@ -399,7 +404,26 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 	_hasErrors(errors) {
 		return errors.length > 0;
 	}
+	_checkNotifications(orgs) {
+		const nowHasNotifications = orgs.value.some((org) => { return org.hasNotification; });
 
+		if (this._hasNotifications !== nowHasNotifications) {
+			this._hasNotifications = nowHasNotifications;
+			this.dispatchEvent(
+				new CustomEvent(
+					'd2l-organization-consortium-tabs-notification-update',
+					{
+						detail: {
+							hasOrgTabNotifications: nowHasNotifications
+						},
+						bubbles: true,
+						composed: true
+					}
+				)
+			);
+		}
+
+	}
 }
 
 window.customElements.define(OrganizationConsortiumTabs.is, OrganizationConsortiumTabs);

--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -407,22 +407,23 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 	_checkNotifications(orgs) {
 		const nowHasNotifications = orgs.value.some((org) => { return org.hasNotification; });
 
-		if (this._hasNotifications !== nowHasNotifications) {
-			this._hasNotifications = nowHasNotifications;
-			this.dispatchEvent(
-				new CustomEvent(
-					'd2l-organization-consortium-tabs-notification-update',
-					{
-						detail: {
-							hasOrgTabNotifications: nowHasNotifications
-						},
-						bubbles: true,
-						composed: true
-					}
-				)
-			);
+		if (this._hasNotifications === nowHasNotifications) {
+			return;
 		}
 
+		this._hasNotifications = nowHasNotifications;
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-organization-consortium-tabs-notification-update',
+				{
+					detail: {
+						hasOrgTabNotifications: nowHasNotifications
+					},
+					bubbles: true,
+					composed: true
+				}
+			)
+		);
 	}
 }
 

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -238,17 +238,54 @@ describe('d2l-organization-consortium-tabs', function() {
 		it('alerts and orgs gets updated when entity changes', function(done) {
 			const component = fixture('org-consortium-with-url-change');
 			component.href = '/consortium-root1.json';
-			setTimeout(function() {
-				component.href = '/consortium-root2.json';
 
-				afterNextRender(component, function() {
-					const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
-					assert.equal(dots.length, 2);
-					assert.isTrue(dots[0].hasAttribute('hidden'));
-					assert.isFalse(dots[1].hasAttribute('hidden'));
-					done();
-				});
-			}, 100);
+			afterNextRender(component, function() {
+				const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
+				assert.equal(dots.length, 2);
+				assert.isFalse(dots[0].hasAttribute('hidden'));
+				assert.isTrue(dots[1].hasAttribute('hidden'));
+
+				setTimeout(function() {
+					component.href = '/consortium-root2.json';
+
+					afterNextRender(component, function() {
+						const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
+						assert.equal(dots.length, 2);
+						assert.isTrue(dots[0].hasAttribute('hidden'));
+						assert.isTrue(dots[1].hasAttribute('hidden'));
+						done();
+					});
+				}, 100);
+			});
+		});
+
+		it('d2l-organization-consortium-tabs-notification-update event is fired when notifications appear and disappear', function(done) {
+			const component = fixture('org-consortium-with-url-change');
+			let firstPass = true;
+			component.addEventListener('d2l-organization-consortium-tabs-notification-update', function(e) {
+				if (firstPass) {
+					firstPass = false;
+					assert.isTrue(e.detail.hasOrgTabNotifications);
+					afterNextRender(component, function() {
+						const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
+						assert.equal(dots.length, 2);
+						assert.isFalse(dots[0].hasAttribute('hidden'));
+						assert.isTrue(dots[1].hasAttribute('hidden'));
+
+						component.href = '/consortium-root2.json';
+					});
+				} else {
+					assert.isFalse(e.detail.hasOrgTabNotifications);
+					afterNextRender(component, function() {
+						const dots = component.shadowRoot.querySelectorAll('d2l-navigation-notification-icon');
+						assert.equal(dots.length, 2);
+						assert.isTrue(dots[0].hasAttribute('hidden'));
+						assert.isTrue(dots[1].hasAttribute('hidden'));
+						done();
+					});
+				}
+			});
+			component.href = '/consortium-root1.json';
 		});
 	});
 

--- a/test/d2l-organization-consortium/data.js
+++ b/test/d2l-organization-consortium/data.js
@@ -249,7 +249,7 @@ export const organization4 = {
 	},
 	'links': [{
 		'rel': ['https://api.brightspace.com/rels/notification-alerts'],
-		'href': '/has-unread'
+		'href': '/no-unread'
 	}, {
 		'rel': ['https://api.brightspace.com/rels/organization-homepage'],
 		'href': '?consortium=4'


### PR DESCRIPTION
When in the mobile view, the org tabs go inside the mobile menu.  We want to add a notification dot to the hamburger button if any of the org tabs have notifications.

If at least one of the org tabs has a notification, the `d2l-organization-consortium-tabs-notification-update` event will be fired.  If something changes after the cache update or during the poll for new notifications (going from no notifications to some, or going from some to none), additional events will be sent.  This goes along with a PR in the LE to listen for this event and add/remove the notification dot as needed.

This will be added to 20.19.11 and master.