### PR TITLE
Render default Organization Availability Set

### DIFF
--- a/components/d2l-organization-availability-set/.eslintrc.json
+++ b/components/d2l-organization-availability-set/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "brightspace/lit-config"
+}

--- a/components/d2l-organization-availability-set/README.MD
+++ b/components/d2l-organization-availability-set/README.MD
@@ -1,3 +1,22 @@
-# TODO
-- shell component just to get everything setup first
-- actual implementations
+# Organization Availability Set
+
+## d2l-organization-availability-set
+
+The `d2l-organization-availability-set` can be used to edit availability sets
+
+### Usage
+
+```html
+<script type="module">
+  import 'd2l-organizations/components/d2l-organization-availability-set/d2l-organization-availability-set.js';
+</script>
+<d2l-organization-availability-set
+	token="TOKEN"
+	href="https://dd7b6b0b-a7eb-45fa-a92d-b8b8c3946d3b.organizations.api.dev.brightspace.com/6606/availability-set/NjYwNl8xMDEwNTE2XzI1NDAwMF80NTA"
+></d2l-organization-availability-set>
+```
+
+***Properties:***
+
+* `token` : An auth token or auth token function for authorizing the fetch of the availability-set
+* `href` : An OuAvailabilitySetUsage resource URL for the availability-set to be edited

--- a/components/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -5,11 +5,12 @@ import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 import { getLocalizeResources } from './localization.js';
 
-class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {
+class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
-			_name: { type: String }
+			_name: { type: String },
+			_canDeleteAvailability: { type: Boolean }
 		};
 	}
 
@@ -30,10 +31,10 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 
 	constructor() {
 		super();
-        this._setEntityType(OrganizationAvailabilityEntity);
-    }
+		this._setEntityType(OrganizationAvailabilityEntity);
+	}
 
-    set _entity(entity) {
+	set _entity(entity) {
 		this._onAvailabilityChange(entity);
 		super._entity = entity;
 	}
@@ -41,43 +42,25 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 	_onAvailabilityChange(entity) {
 		if (entity) {
 			this._setName(entity);
+			this._canDeleteAvailability = entity.canDeleteAvailability();
 		}
 	}
 
 	_setName(entity) {
 		if (entity) {
 			entity.onOrganizationChange(organization => {
-				this._name = organization.name();
+				this._name = organization.name()
 			});
 		}
 	}
 
-	_renderItemDescription(entity, name) {
-		if (entity) {
-			const type = entity.getCurrentTypeName();
-
-			if (entity.isExplicitAvailability()) {
-				return this.localize('explicitItemDescription', { type, name });
-			}
-
-			if (entity.isInheritAvailability()) {
-				const descendentType = entity.getDescendentTypeName();
-
-				if (descendentType) {
-					return this.localize('inheritItemWithDescendentTypeDescription', { type, name, descendentType });
-				}
-				return this.localize('inheritItemDescription', { type, name });
-			}
-		}
-	}
-
 	render() {
-        return html`
-			${this._renderItemDescription(super._entity, this._name)}
+		return html`
+			<d2l-input-checkbox checked ?disabled="${!this._canDeleteAvailability}">
+				${this.localize('currentOrgUnitItemDescription', { name: this._name })}
+			</d2l-input-checkbox>
 		`;
 	}
-
-
 };
 
-customElements.define('d2l-organization-availability', OrganizationAvailability);
+customElements.define('d2l-current-organization-availability', CurrentOrganizationAvailability);

--- a/components/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -1,9 +1,9 @@
-import { LitElement, css, html } from 'lit-element/lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import '@brightspace-ui/core/components/inputs/input-checkbox';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { getLocalizeResources } from './localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
 
 class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
@@ -49,7 +49,7 @@ class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitEl
 	_setName(entity) {
 		if (entity) {
 			entity.onOrganizationChange(organization => {
-				this._name = organization.name()
+				this._name = organization.name();
 			});
 		}
 	}
@@ -61,6 +61,6 @@ class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitEl
 			</d2l-input-checkbox>
 		`;
 	}
-};
+}
 
 customElements.define('d2l-current-organization-availability', CurrentOrganizationAvailability);

--- a/components/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit-element/lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-
+import '@brightspace-ui/core/components/inputs/input-checkbox';
 import { getLocalizeResources } from './localization.js';
 
 class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {

--- a/components/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -77,7 +77,11 @@ class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElemen
 				`
 			}
 			${this._canAddAvailability ?
-				html`<d2l-button @click=${this.handleAddOrgUnits}>Add Org Units</d2l-button>` : ''
+				html`
+					<d2l-button @click=${this.handleAddOrgUnits}>
+						${this.localize('addOrgUnits')}
+					</d2l-button>
+				` : ''
 			}
 			${this._availabilityEntities.map(entity =>
 				html`

--- a/components/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -1,29 +1,98 @@
 import { LitElement, css, html } from 'lit-element/lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { OrganizationAvailabilitySetEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilitySetEntity.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import '@brightspace-ui/core/components/button/button';
 
-const wc = class extends LitElement {
+import { getLocalizeResources } from './localization.js';
+import './d2l-organization-availability.js';
+
+class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElement)) {
+
 	static get properties() {
 		return {
+			_availabilityEntities: { type: Array },
+			_currentOrgUnitAvailabilityEntity: { type: Object },
+			_canAddAvailability: { type: Boolean },
+			_currentOrgUnitName: { type: String }
 		};
 	}
 
 	static get styles() {
-		return [css`
+		return css`
 			:host {
 				display: block;
 			}
-		`];
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs);
 	}
 
 	constructor() {
 		super();
+		this._availabilityEntities = [];
+		this._setEntityType(OrganizationAvailabilitySetEntity);
 		if (D2L.Dialog && D2L.Dialog.OrgUnitSelector) {
 			this._dialog = new D2L.Dialog.OrgUnitSelector(this.handleOrgUnitSelect);
 		}
 	}
 
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			super._entity = entity;
+			this._onAvailabilitySetChange(entity);
+		}
+	}
+
+	_onAvailabilitySetChange(entity) {
+		if (entity) {
+			this._availabilityEntities = entity.getAvailabilityEntitiesWithoutCurrentOrgUnit();
+			this._canAddAvailability = entity.canAddAvailability();
+			this._currentOrgUnitAvailabilityEntity = entity.getCurrentOrgUnitAvailability();
+			entity.onOrganizationChange(organization => {
+				this._currentOrgUnitName = organization.name();
+			});
+		}
+	}
+
+	_renderCurrentOrgUnit(currentOrgUnitAvailabilityEntity, currentOrgUnitName, canAddAvailability) {
+		if (currentOrgUnitAvailabilityEntity) {
+			return html`
+					<d2l-organization-availability
+						.isCurrentOrgUnit="${!!currentOrgUnitAvailabilityEntity}"
+						.href="${currentOrgUnitAvailabilityEntity.href}"
+						.token="${this.token}">
+					</d2l-organization-availability>
+			`;
+		} else {
+			return html`
+				<d2l-input-checkbox ?disabled="${!canAddAvailability}">
+					${this.localize('currentOrgUnitItemDescription', { name: currentOrgUnitName })}
+				</d2l-input-checkbox>
+			`;
+		}
+	}
+
 	render() {
-		return html`<d2l-button @click=${this.handleAddOrgUnits}>Add Org Units</d2l-button>
+		return html`
+			${this._renderCurrentOrgUnit(this._currentOrgUnitAvailabilityEntity, this._currentOrgUnitName, this._canAddAvailability)}
+			${this._canAddAvailability ?
+				html`<d2l-button @click=${this.handleAddOrgUnits}>Add Org Units</d2l-button>`
+				: ''
+			}
+			${this._availabilityEntities.map(entity =>
+				html`
+					<d2l-organization-availability
+						.href="${entity.href}"
+						.token="${this.token}">
+					</d2l-organization-availability>
+				`
+			)}
 		`;
 	}
 
@@ -37,4 +106,4 @@ const wc = class extends LitElement {
 	}
 };
 
-customElements.define('d2l-organization-availability-set', wc);
+customElements.define('d2l-organization-availability-set', OrganizationAvailabilitySet);

--- a/components/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -1,12 +1,11 @@
-import { LitElement, css, html } from 'lit-element/lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { OrganizationAvailabilitySetEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilitySetEntity.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import '@brightspace-ui/core/components/button/button';
-
-import { getLocalizeResources } from './localization.js';
-import './d2l-organization-availability.js';
 import './d2l-current-organization-availability.js';
+import './d2l-organization-availability.js';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { getLocalizeResources } from './localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { OrganizationAvailabilitySetEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilitySetEntity.js';
 
 class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
@@ -63,34 +62,27 @@ class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElemen
 
 	render() {
 		return html`
-			${this._currentOrgUnitEntity ?
-				html`
-					<d2l-current-organization-availability
-						.href="${this._currentOrgUnitEntity.href}"
-						.token="${this.token}">
-					</d2l-current-organization-availability>
-				` :
-				html`
-					<d2l-input-checkbox ?disabled="${!this._canAddAvailability}">
-						${this.localize('currentOrgUnitItemDescription', { name: this._currentOrgUnitName })}
-					</d2l-input-checkbox>
-				`
-			}
-			${this._canAddAvailability ?
-				html`
-					<d2l-button @click=${this.handleAddOrgUnits}>
-						${this.localize('addOrgUnits')}
-					</d2l-button>
-				` : ''
-			}
-			${this._availabilityEntities.map(entity =>
-				html`
-					<d2l-organization-availability
-						.href="${entity.href}"
-						.token="${this.token}">
-					</d2l-organization-availability>
-				`
-			)}
+			${this._currentOrgUnitEntity ? html`
+				<d2l-current-organization-availability
+					.href="${this._currentOrgUnitEntity.href}"
+					.token="${this.token}">
+				</d2l-current-organization-availability>
+			` : html`
+				<d2l-input-checkbox ?disabled="${!this._canAddAvailability}">
+					${this.localize('currentOrgUnitItemDescription', { name: this._currentOrgUnitName })}
+				</d2l-input-checkbox>
+			`}
+			${this._canAddAvailability && html`
+				<d2l-button @click=${this.handleAddOrgUnits}>
+					${this.localize('addOrgUnits')}
+				</d2l-button>
+			`}
+			${this._availabilityEntities.map(entity => html`
+				<d2l-organization-availability
+					.href="${entity.href}"
+					.token="${this.token}">
+				</d2l-organization-availability>
+			`)}
 		`;
 	}
 
@@ -102,6 +94,6 @@ class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElemen
 			this._dialog.Open();
 		}
 	}
-};
+}
 
 customElements.define('d2l-organization-availability-set', OrganizationAvailabilitySet);

--- a/components/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -6,13 +6,14 @@ import '@brightspace-ui/core/components/button/button';
 
 import { getLocalizeResources } from './localization.js';
 import './d2l-organization-availability.js';
+import './d2l-current-organization-availability.js';
 
 class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
 			_availabilityEntities: { type: Array },
-			_currentOrgUnitAvailabilityEntity: { type: Object },
+			_currentOrgUnitEntity: { type: Object },
 			_canAddAvailability: { type: Boolean },
 			_currentOrgUnitName: { type: String }
 		};
@@ -51,39 +52,32 @@ class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElemen
 
 	_onAvailabilitySetChange(entity) {
 		if (entity) {
-			this._availabilityEntities = entity.getAvailabilityEntitiesWithoutCurrentOrgUnit();
+			this._availabilityEntities = entity.getEntitiesExcludingCurrentOrgUnit();
 			this._canAddAvailability = entity.canAddAvailability();
-			this._currentOrgUnitAvailabilityEntity = entity.getCurrentOrgUnitAvailability();
+			this._currentOrgUnitEntity = entity.getCurrentOrgUnitEntity();
 			entity.onOrganizationChange(organization => {
 				this._currentOrgUnitName = organization.name();
 			});
 		}
 	}
 
-	_renderCurrentOrgUnit(currentOrgUnitAvailabilityEntity, currentOrgUnitName, canAddAvailability) {
-		if (currentOrgUnitAvailabilityEntity) {
-			return html`
-					<d2l-organization-availability
-						.isCurrentOrgUnit="${!!currentOrgUnitAvailabilityEntity}"
-						.href="${currentOrgUnitAvailabilityEntity.href}"
-						.token="${this.token}">
-					</d2l-organization-availability>
-			`;
-		} else {
-			return html`
-				<d2l-input-checkbox ?disabled="${!canAddAvailability}">
-					${this.localize('currentOrgUnitItemDescription', { name: currentOrgUnitName })}
-				</d2l-input-checkbox>
-			`;
-		}
-	}
-
 	render() {
 		return html`
-			${this._renderCurrentOrgUnit(this._currentOrgUnitAvailabilityEntity, this._currentOrgUnitName, this._canAddAvailability)}
+			${this._currentOrgUnitEntity ?
+				html`
+					<d2l-current-organization-availability
+						.href="${this._currentOrgUnitEntity.href}"
+						.token="${this.token}">
+					</d2l-organization-availability>
+				` :
+				html`
+					<d2l-input-checkbox ?disabled="${!this._canAddAvailability}">
+						${this.localize('currentOrgUnitItemDescription', { name: this._currentOrgUnitName })}
+					</d2l-input-checkbox>
+				`
+			}
 			${this._canAddAvailability ?
-				html`<d2l-button @click=${this.handleAddOrgUnits}>Add Org Units</d2l-button>`
-				: ''
+				html`<d2l-button @click=${this.handleAddOrgUnits}>Add Org Units</d2l-button>` : ''
 			}
 			${this._availabilityEntities.map(entity =>
 				html`

--- a/components/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -68,7 +68,7 @@ class OrganizationAvailabilitySet extends EntityMixinLit(LocalizeMixin(LitElemen
 					<d2l-current-organization-availability
 						.href="${this._currentOrgUnitEntity.href}"
 						.token="${this.token}">
-					</d2l-organization-availability>
+					</d2l-current-organization-availability>
 				` :
 				html`
 					<d2l-input-checkbox ?disabled="${!this._canAddAvailability}">

--- a/components/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability.js
@@ -1,9 +1,8 @@
-import { LitElement, css, html } from 'lit-element/lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-
 import { getLocalizeResources } from './localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
 
 class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
@@ -30,10 +29,10 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 
 	constructor() {
 		super();
-        this._setEntityType(OrganizationAvailabilityEntity);
-    }
+		this._setEntityType(OrganizationAvailabilityEntity);
+	}
 
-    set _entity(entity) {
+	set _entity(entity) {
 		this._onAvailabilityChange(entity);
 		super._entity = entity;
 	}
@@ -72,12 +71,11 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 	}
 
 	render() {
-        return html`
+		return html`
 			${this._renderItemDescription(super._entity, this._name)}
 		`;
 	}
 
-
-};
+}
 
 customElements.define('d2l-organization-availability', OrganizationAvailability);

--- a/components/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability.js
@@ -1,0 +1,96 @@
+import { LitElement, css, html } from 'lit-element/lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { OrganizationAvailabilityEntity } from 'siren-sdk/src/organizations/OrganizationAvailabilityEntity.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+import { getLocalizeResources } from './localization.js';
+import '../d2l-organization-name/d2l-organization-name.js';
+
+
+
+class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement)) {
+
+	static get properties() {
+		return {
+			isCurrentOrgUnit: { type: Boolean },
+			_name: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs);
+	}
+
+	constructor() {
+		super();
+        this._setEntityType(OrganizationAvailabilityEntity);
+    }
+
+    set _entity(entity) {
+		this._onAvailabilityChange(entity);
+		super._entity = entity;
+	}
+
+	_onAvailabilityChange(entity) {
+		if (entity) {
+			this._setName(entity);
+		}
+	}
+
+	_setName(entity) {
+		if (entity) {
+			entity.onOrganizationChange(organization => {
+				this._name = organization.name()
+			});
+		}
+	}
+
+	_renderItemDescription(entity, name) {
+		if (entity) {
+			const canDeleteAvailability = entity.canDeleteAvailability();
+			if (this.isCurrentOrgUnit) {
+				return html`
+					<d2l-input-checkbox checked ?disabled="${!canDeleteAvailability}">
+						${this.localize('currentOrgUnitItemDescription', { name })}
+					</d2l-input-checkbox>
+				`;
+			}
+
+			const type = entity.getCurrentTypeName();
+
+			if (entity.isExplicitAvailability()) {
+				return this.localize('explicitItemDescription', { type, name });
+			}
+
+			if (entity.isInheritAvailability()) {
+				const descendentType = entity.getDescendentTypeName();
+
+				if (descendentType) {
+					return this.localize('inheritItemWithDescendentTypeDescription', { type, name, descendentType });
+				}
+				return this.localize('inheritItemDescription', { type, name });
+			}
+		}
+	}
+
+	render() {
+        return html`
+			${this._renderItemDescription(super._entity, this._name)}
+		`;
+	}
+
+
+};
+
+customElements.define('d2l-organization-availability', OrganizationAvailability);

--- a/components/d2l-organization-availability-set/lang/en.json
+++ b/components/d2l-organization-availability-set/lang/en.json
@@ -1,0 +1,18 @@
+{
+  "currentOrgUnitItemDescription": {
+    "translation": "Current Org Unit: {name}",
+    "context": "Description of an explicit orgunit availability item"
+  },
+  "explicitItemDescription": {
+    "translation": "The {type}: {name}",
+    "context": "Description of an explicit orgunit availability item"
+  },
+  "inheritItemDescription": {
+    "translation": "Every Org Unit under the {type}: {name}",
+    "context": "Description of an inherit (all descendents) orgunit availability item"
+  },
+  "inheritItemWithDescendentTypeDescription": {
+    "translation": "Every {descendentType} under the {type}: {name}",
+    "context": "Description of an inherit with specific {descendentType} orgunit availability item"
+  }
+}

--- a/components/d2l-organization-availability-set/lang/en.json
+++ b/components/d2l-organization-availability-set/lang/en.json
@@ -1,4 +1,8 @@
 {
+  "addOrgUnits": {
+    "translation": "Add Org Units",
+    "context": "Add Org Units"
+  },
   "currentOrgUnitItemDescription": {
     "translation": "Current Org Unit: {name}",
     "context": "Description of an explicit orgunit availability item"

--- a/components/d2l-organization-availability-set/localization.js
+++ b/components/d2l-organization-availability-set/localization.js
@@ -1,0 +1,40 @@
+import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
+
+const SUPPORTED_LANGUAGES = ['en', 'fr'];
+const cache = {};
+const baseUrl = import.meta.url;
+
+export async function getLocalizeResources(langs) {
+	const supportedLanguages = langs.reverse().filter(language => {
+		return SUPPORTED_LANGUAGES.indexOf(language) > -1;
+	});
+
+	const sergeLangterms = supportedLanguages.map(language => {
+		const url = resolveUrl(`./lang/${language}.json`, baseUrl);
+		if (cache[url]) {
+			return cache[url];
+		}
+
+		const langterms = fetch(url).then(res => res.json()).then(json => {
+			const langterms = {};
+			for (const langterm in json) {
+				langterms[langterm] = json[langterm].translation;
+			}
+			return langterms;
+		});
+		cache[url] = langterms;
+		return langterms;
+	});
+
+	const responses = await Promise.all(sergeLangterms);
+
+	const langterms = {};
+	responses.forEach(language => {
+		Object.assign(langterms, language);
+	});
+
+	return {
+		language: supportedLanguages[supportedLanguages.length - 1],
+		resources: langterms
+	};
+}

--- a/components/d2l-organization-availability-set/localization.js
+++ b/components/d2l-organization-availability-set/localization.js
@@ -1,6 +1,6 @@
 import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
-const SUPPORTED_LANGUAGES = ['en', 'fr'];
+const SUPPORTED_LANGUAGES = ['ar', 'de', 'en', 'es', 'fi', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh', 'zh-tw'];
 const cache = {};
 const baseUrl = import.meta.url;
 

--- a/demo/d2l-organization-availability-set/d2l-organization-availability-set.html
+++ b/demo/d2l-organization-availability-set/d2l-organization-availability-set.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-organization-availability-set demo</title>
+		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
+
+		<script type="module">
+			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+			import '@polymer/iron-demo-helpers/demo-snippet';
+			import 'd2l-typography/d2l-typography.js';
+			import '../../components/d2l-organization-availability-set/d2l-current-organization-availability.js';
+			import '../../components/d2l-organization-availability-set/d2l-organization-availability-set.js';
+			import '../../components/d2l-organization-availability-set/d2l-organization-availability.js';
+
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = `
+				<custom-style>
+					<style is="custom-style" include="demo-pages-shared-styles"></style>
+				</custom-style>
+				<custom-style include="d2l-typography">
+					<style is="custom-style" include="d2l-typography">
+						html {
+							font-size: 20px;
+						}
+						h3 {
+							text-align: center;
+						}
+						.demo {
+							align-items: center;
+  							background-image: linear-gradient(to bottom, #f6f7f8, #f6f7f8), linear-gradient(to top, #ffffff, #f9fafb);
+							padding: 50px;
+						}
+					</style>
+				</custom-style>
+			`;
+			document.body.appendChild($_documentContainer.content);
+			window.D2L.Siren.WhitelistBehavior._inTestMode = true;
+		</script>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container">
+			<h3>d2l-organization-availability-set demo</h3>
+			<demo-snippet>
+				<template>
+					<div class="demo">
+						<d2l-organization-availability-set href="../data/organization-availability-set/organization-availability-set.json" token="whatever"></d2l-organization-availability-set>
+					</div>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-current-organization-availability demo</h3>
+			<demo-snippet>
+				<template>
+					<div class="demo">
+						<d2l-current-organization-availability href="../data/organization-availability-set/orgUnitAvailabilityCurrent.json" token="whatever"></d2l-current-organization-availability>
+					</div>
+				</template>
+			</demo-snippet>
+
+			<h3>d2l-organization-availability demo</h3>
+			<demo-snippet>
+				<template>
+					<div class="demo">
+						<d2l-organization-availability href="../data/organization-availability-set/orgUnitAvailabilityExplicit.json" token="whatever"></d2l-organization-availability>
+						<d2l-organization-availability href="../data/organization-availability-set/orgUnitAvailabilityInheritWithType.json" token="whatever"></d2l-organization-availability>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/data/organization-availability-set/orgUnitAvailabilityCurrent.json
+++ b/demo/data/organization-availability-set/orgUnitAvailabilityCurrent.json
@@ -1,0 +1,52 @@
+{
+	"class": [
+		"orgunit-availability",
+		"explicit",
+		"current"
+	],
+	"rel": [
+		"https://api.brightspace.com/rels/cache-primer"
+	],
+	"entities": [
+		{
+			"class": [
+				"current",
+				"orgunit-type"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/organization-type"
+			],
+			"properties": {
+				"name": "Organization"
+			}
+		}
+	],
+	"actions": [
+		{
+			"title": "Delete Item",
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityCurrent.json",
+			"name": "delete-item",
+			"method": "DELETE"
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityCurrent.json"
+		},
+		{
+			"rel": [
+				"collection"
+			],
+			"href": "/demo/data/organization-availability-set/organizationAvailabilitySet.json"
+		},
+		{
+			"rel": [
+				"https://api.brightspace.com/rels/organization"
+			],
+			"href": "/demo/data/organization-availability-set/organization6606.json"
+		}
+	]
+}

--- a/demo/data/organization-availability-set/orgUnitAvailabilityExplicit.json
+++ b/demo/data/organization-availability-set/orgUnitAvailabilityExplicit.json
@@ -1,0 +1,51 @@
+{
+	"class": [
+		"orgunit-availability",
+		"explicit"
+	],
+	"rel": [
+		"https://api.brightspace.com/rels/cache-primer"
+	],
+	"entities": [
+		{
+			"class": [
+				"current",
+				"orgunit-type"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/organization-type"
+			],
+			"properties": {
+				"name": "Course Offering"
+			}
+		}
+	],
+	"actions": [
+		{
+			"title": "Delete Item",
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityExplicit.json",
+			"name": "delete-item",
+			"method": "DELETE"
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityExplicit.json"
+		},
+		{
+			"rel": [
+				"collection"
+			],
+			"href": "/demo/data/organization-availability-set/organizationAvailabilitySet.json"
+		},
+		{
+			"rel": [
+				"https://api.brightspace.com/rels/organization"
+			],
+			"href": "/demo/data/organization-availability-set/organization6609.json"
+		}
+	]
+}

--- a/demo/data/organization-availability-set/orgUnitAvailabilityInheritWithType.json
+++ b/demo/data/organization-availability-set/orgUnitAvailabilityInheritWithType.json
@@ -1,0 +1,63 @@
+{
+	"class": [
+		"orgunit-availability",
+		"inherit"
+	],
+	"rel": [
+		"https://api.brightspace.com/rels/cache-primer"
+	],
+	"entities": [
+		{
+			"class": [
+				"descendent",
+				"orgunit-type"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/organization-type"
+			],
+			"properties": {
+				"name": "Program"
+			}
+		},
+		{
+			"class": [
+				"current",
+				"orgunit-type"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/organization-type"
+			],
+			"properties": {
+				"name": "Department"
+			}
+		}
+	],
+	"actions": [
+		{
+			"title": "Delete Item",
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityInheritWithType.json",
+			"name": "delete-item",
+			"method": "DELETE"
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityInheritWithType.json"
+		},
+		{
+			"rel": [
+				"collection"
+			],
+			"href": "/demo/data/organization-availability-set/organizationAvailabilitySet.json"
+		},
+		{
+			"rel": [
+				"https://api.brightspace.com/rels/organization"
+			],
+			"href": "/demo/data/organization-availability-set/organization121147.json"
+		}
+	]
+}

--- a/demo/data/organization-availability-set/organization-availability-set.json
+++ b/demo/data/organization-availability-set/organization-availability-set.json
@@ -1,0 +1,85 @@
+{
+	"class": [
+		"collection",
+		"orgunit-availability-set"
+	],
+	"entities": [
+		{
+			"class": [
+				"orgunit-availability",
+				"explicit",
+				"current"
+			],
+			"rel": [
+				"item"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityCurrent.json"
+		},
+		{
+			"class": [
+				"orgunit-availability",
+				"explicit"
+			],
+			"rel": [
+				"item"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityExplicit.json"
+		},
+		{
+			"class": [
+				"orgunit-availability",
+				"inherit"
+			],
+			"rel": [
+				"item"
+			],
+			"href": "/demo/data/organization-availability-set/orgUnitAvailabilityInheritWithType.json"
+		}
+	],
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/organization-availability-set.json"
+		},
+		{
+			"rel": [
+				"https://api.brightspace.com/rels/organization"
+			],
+			"href": "/demo/data/organization-availability-set/organization6606.json"
+		}
+	],
+	"actions": [
+		{
+			"type": "application/x-www-form-urlencoded",
+			"title": "Create Explicit Availability Item",
+			"href": "/demo/data/organization-availability-set/organization-availability-set.json",
+			"name": "create-explicit-availability-item",
+			"method": "POST",
+			"fields": [
+				{
+					"type": "number",
+					"name": "explicitOrgUnitId"
+				}
+			]
+		},
+		{
+			"type": "application/x-www-form-urlencoded",
+			"title": "Create Inherited Availability Item",
+			"href": "/demo/data/organization-availability-set/organization-availability-set.json",
+			"name": "create-inherited-availability-item",
+			"method": "POST",
+			"fields": [
+				{
+					"type": "number",
+					"name": "ancestorOrgUnitId"
+				},
+				{
+					"type": "number",
+					"name": "descendentOrgUnitTypeId"
+				}
+			]
+		}
+	]
+}

--- a/demo/data/organization-availability-set/organization121147.json
+++ b/demo/data/organization-availability-set/organization121147.json
@@ -1,0 +1,22 @@
+{
+	"class": [
+		"active",
+		"department"
+	],
+	"properties": {
+		"name": "Accounting&Financial Management",
+		"code": "AFM",
+		"startDate": null,
+		"endDate": null,
+		"isActive": true,
+		"description": null
+	},
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/organization121147.json"
+		}
+	]
+}

--- a/demo/data/organization-availability-set/organization6606.json
+++ b/demo/data/organization-availability-set/organization6606.json
@@ -1,0 +1,22 @@
+{
+	"class": [
+		"active",
+		"organization"
+	],
+	"properties": {
+		"name": "Dev",
+		"code": null,
+		"startDate": null,
+		"endDate": null,
+		"isActive": true,
+		"description": null
+	},
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/organization6606.json"
+		}
+	]
+}

--- a/demo/data/organization-availability-set/organization6609.json
+++ b/demo/data/organization-availability-set/organization6609.json
@@ -1,0 +1,22 @@
+{
+	"class": [
+		"active",
+		"course-offering"
+	],
+	"properties": {
+		"name": "Course",
+		"code": "C1",
+		"startDate": null,
+		"endDate": null,
+		"isActive": true,
+		"description": null
+	},
+	"links": [
+		{
+			"rel": [
+				"self"
+			],
+			"href": "/demo/data/organization-availability-set/organization6609.json"
+		}
+	]
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -34,6 +34,7 @@
 			<h3>Demos</h3>
 			<ul>
 				<h4>Organization Components</h4>
+				<li><a href="d2l-organization-availability-set/d2l-organization-availability-set.html">d2l-organization-availability-set</a></li>
 				<li><a href="d2l-organization-consortium/d2l-organization-consortium.html">d2l-organization-consortium</a></li>
 				<li><a href="d2l-organization-date/d2l-organization-date-demo.html">d2l-organization-date</a></li>
 				<li><a href="d2l-organization-detail-card/d2l-organization-detail-card-demo.html">d2l-organization-detail-card</a></li>

--- a/organizations.serge.json
+++ b/organizations.serge.json
@@ -120,6 +120,8 @@
       "zh-cn zh",
       "zh-tw zh-tw"
     ],
-    "pr_reviewers": []
+    "pr_reviewers": [
+      "wongvincent"
+    ]
   }
 ]

--- a/organizations.serge.json
+++ b/organizations.serge.json
@@ -100,5 +100,26 @@
     "pr_reviewers": [
       "ctwomey1"
     ]
+  },
+  {
+    "name": "availabilitySet",
+    "source_dir": "components/d2l-organization-availability-set/lang",
+    "output_file_path": "components/d2l-organization-availability-set/lang/%LANG%.json",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ],
+    "pr_reviewers": []
   }
 ]

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^4.2.0",
     "eslint-config-brightspace": "^0.6.3",
     "eslint-plugin-html": "^4.0.1",
+    "eslint-plugin-lit": "^1.2.0",
     "eslint-plugin-sort-class-members": "^1.4.0",
     "frau-ci": "^1.40.0",
     "gulp": "^4.0.0",

--- a/test/d2l-organization-availability-set/d2l-current-organization-availability.html
+++ b/test/d2l-organization-availability-set/d2l-current-organization-availability.html
@@ -6,15 +6,15 @@
 		<script src="../../../wct-browser-legacy/browser.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-		<script type="module" src="../../components/d2l-organization-availability-set/d2l-organization-availability-set.js"></script>
+		<script type="module" src="../../components/d2l-organization-availability-set/d2l-current-organization-availability.js"></script>
 	</head>
 	<body>
-		<test-fixture id="org-availability-set">
+		<test-fixture id="current-org-availability">
 			<template>
-				<d2l-organization-availability-set token="whatever"></d2l-organization-availability-set>
+				<d2l-current-organization-availability token="whatever"></d2l-current-organization-availability>
 			</template>
 		</test-fixture>
 
-		<script type="module" src="./d2l-organization-availability-set.js"></script>
+		<script type="module" src="./d2l-current-organization-availability.js"></script>
 	</body>
 </html>

--- a/test/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -32,14 +32,12 @@ describe('d2l-current-organization-availability', () => {
 			expect(component._name).to.equal('Dev');
 			expect(component._canDeleteAvailability).to.be.true;
 
-			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked]');
-			expect(checkboxElems.length).to.equal(1);
-
-			// This nested afterNextRender is required for the test to pass
-			afterNextRender(component, () => {
+			setTimeout(() => {
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked]');
+				expect(checkboxElems.length).to.equal(1);
 				expect(checkboxElems[0].textContent.trim()).to.equal('Current Org Unit: Dev');
 				done();
-			});
+			}, 200);
 		});
 	});
 
@@ -49,11 +47,12 @@ describe('d2l-current-organization-availability', () => {
 			expect(component._name).to.equal('Dev');
 			expect(component._canDeleteAvailability).to.be.false;
 
-			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked][disabled]');
-			expect(checkboxElems.length).to.equal(1);
-			expect(checkboxElems[0].textContent.trim()).to.equal('Current Org Unit: Dev');
-
-			done();
+			setTimeout(() => {
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked][disabled]');
+				expect(checkboxElems.length).to.equal(1);
+				expect(checkboxElems[0].textContent.trim()).to.equal('Current Org Unit: Dev');
+				done();
+			}, 200);
 		});
 	});
 });

--- a/test/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -1,0 +1,59 @@
+import { Organizations, OrgUnitAvailability } from './data.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+
+window.D2L.Siren.WhitelistBehavior._testMode(true);
+
+describe('d2l-current-organization-availability', () => {
+	var component, sandbox;
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+			const whatToFetch = {
+				'/orgUnitAvailability1.json': OrgUnitAvailability.current,
+				'/organization6606.json': Organizations.Org6606,
+				'/orgUnitAvailability5.json': OrgUnitAvailability.currentCannotDelete
+			};
+			return Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(whatToFetch[input]); }
+			});
+		});
+
+		component = fixture('current-org-availability');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('renders current availability', (done) => {
+		component.href = '/orgUnitAvailability1.json';
+		afterNextRender(component, () => {
+			expect(component._name).to.equal('Dev');
+			expect(component._canDeleteAvailability).to.be.true;
+
+			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked]');
+			expect(checkboxElems.length).to.equal(1);
+
+			// This nested afterNextRender is required for the test to pass
+			afterNextRender(component, () => {
+				expect(checkboxElems[0].textContent.trim()).to.equal('Current Org Unit: Dev');
+				done();
+			});
+		});
+	});
+
+	it('renders current availability with disabled checkbox', (done) => {
+		component.href = '/orgUnitAvailability5.json';
+		afterNextRender(component, () => {
+			expect(component._name).to.equal('Dev');
+			expect(component._canDeleteAvailability).to.be.false;
+
+			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox[checked][disabled]');
+			expect(checkboxElems.length).to.equal(1);
+			expect(checkboxElems[0].textContent.trim()).to.equal('Current Org Unit: Dev');
+
+			done();
+		});
+	});
+});

--- a/test/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -1,0 +1,111 @@
+import { OrganizationAvailabilitySet, Organizations, OrgUnitAvailability } from './data.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+
+window.D2L.Siren.WhitelistBehavior._testMode(true);
+
+describe('d2l-organization-availability-set', () => {
+	describe('fetching organization-availability-set', () => {
+		var component, sandbox;
+		beforeEach(() => {
+			sandbox = sinon.sandbox.create();
+			sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+				const whatToFetch = {
+					'/organizationAvailabilitySet.json': OrganizationAvailabilitySet.default,
+					'/organizationAvailabilitySetCannotAdd.json': OrganizationAvailabilitySet.cannotAdd,
+					'/organizationAvailabilitySetWithoutCurrentOrgUnit.json': OrganizationAvailabilitySet.withoutCurrentOrgUnit,
+					'/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json': OrganizationAvailabilitySet.cannotAddAndWithoutCurrentOrgUnit,
+					'/orgUnitAvailability1.json': OrgUnitAvailability.current,
+					'/orgUnitAvailability2.json': OrgUnitAvailability.explicit,
+					'/orgUnitAvailability3.json': OrgUnitAvailability.inherit,
+					'/orgUnitAvailability4.json': OrgUnitAvailability.inheritWithDescendentType,
+					'/organization6606.json': Organizations.Org6606
+				};
+				return Promise.resolve({
+					ok: true,
+					json: () => { return Promise.resolve(whatToFetch[input]); }
+				});
+			});
+
+			component = fixture('org-availability-set');
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
+
+		it('renders organization availability set', (done) => {
+			component.href = '/organizationAvailabilitySet.json';
+			afterNextRender(component, () => {
+				expect(component._availabilityEntities).to.have.lengthOf(3);
+				expect(component._currentOrgUnitEntity.class).to.include('current');
+				expect(component._canAddAvailability).to.be.true;
+				expect(component._currentOrgUnitName).to.equal('Dev');
+
+				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+				expect(currentOrgUnitElems.length).to.equal(1);
+
+				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+				expect(buttonElems.length).to.equal(1);
+				expect(buttonElems[0].textContent).to.equal('Add Org Units');
+
+				const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
+				expect(availabilityElems.length).to.equal(3);
+
+				done();
+			});
+		});
+
+		it('does not render Add Org Unit button when missing action', (done) => {
+			component.href = '/organizationAvailabilitySetCannotAdd.json';
+			afterNextRender(component, () => {
+				expect(component._canAddAvailability).to.be.false;
+
+				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+				expect(buttonElems.length).to.equal(0);
+
+				done();
+			});
+		});
+
+		it('does not render current-organization-availability component if current org unit unchecked', (done) => {
+			component.href = '/organizationAvailabilitySetWithoutCurrentOrgUnit.json';
+			afterNextRender(component, () => {
+				expect(component._availabilityEntities).to.have.lengthOf(3);
+				expect(component._currentOrgUnitEntity).to.be.undefined;
+				expect(component._canAddAvailability).to.be.true;
+
+				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+				expect(currentOrgUnitElems.length).to.equal(0);
+
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+				expect(checkboxElems.length).to.equal(1);
+				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+
+				const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
+				expect(availabilityElems.length).to.equal(3);
+
+				done();
+			});
+		});
+
+		it('does not render current-organization-availability component if current org unit unchecked and does not render Add Org Units button if action is missing', (done) => {
+			component.href = '/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json';
+			afterNextRender(component, () => {
+				expect(component._currentOrgUnitEntity).to.be.undefined;
+				expect(component._canAddAvailability).to.be.false;
+
+				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+				expect(currentOrgUnitElems.length).to.equal(0);
+
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+				expect(checkboxElems.length).to.equal(1);
+				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+
+				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+				expect(buttonElems.length).to.equal(0);
+
+				done();
+			});
+		});
+	});
+});

--- a/test/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -44,14 +44,15 @@ describe('d2l-organization-availability-set', () => {
 				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
 				expect(currentOrgUnitElems.length).to.equal(1);
 
-				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
-				expect(buttonElems.length).to.equal(1);
-				expect(buttonElems[0].textContent).to.equal('Add Org Units');
-
 				const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
 				expect(availabilityElems.length).to.equal(3);
 
-				done();
+				afterNextRender(component, () => {
+					const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+					expect(buttonElems.length).to.equal(1);
+					expect(buttonElems[0].textContent.trim()).to.equal('Add Org Units');
+					done();
+				});
 			});
 		});
 

--- a/test/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -46,12 +46,9 @@ describe('d2l-organization-availability-set', () => {
 			const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
 			expect(availabilityElems.length).to.equal(3);
 
-			afterNextRender(component, () => {
-				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
-				expect(buttonElems.length).to.equal(1);
-				expect(buttonElems[0].textContent.trim()).to.equal('Add Org Units');
-				done();
-			});
+			const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+			expect(buttonElems.length).to.equal(1);
+			done();
 		});
 	});
 
@@ -77,14 +74,15 @@ describe('d2l-organization-availability-set', () => {
 			const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
 			expect(currentOrgUnitElems.length).to.equal(0);
 
-			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
-			expect(checkboxElems.length).to.equal(1);
-			expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
-
 			const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
 			expect(availabilityElems.length).to.equal(3);
 
-			done();
+			setTimeout(() => {
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+				expect(checkboxElems.length).to.equal(1);
+				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+				done();
+			}, 200);
 		});
 	});
 
@@ -97,14 +95,15 @@ describe('d2l-organization-availability-set', () => {
 			const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
 			expect(currentOrgUnitElems.length).to.equal(0);
 
-			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
-			expect(checkboxElems.length).to.equal(1);
-			expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
-
 			const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
 			expect(buttonElems.length).to.equal(0);
 
-			done();
+			setTimeout(() => {
+				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+				expect(checkboxElems.length).to.equal(1);
+				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+				done();
+			}, 200);
 		});
 	});
 });

--- a/test/d2l-organization-availability-set/d2l-organization-availability-set.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability-set.js
@@ -4,109 +4,107 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 window.D2L.Siren.WhitelistBehavior._testMode(true);
 
 describe('d2l-organization-availability-set', () => {
-	describe('fetching organization-availability-set', () => {
-		var component, sandbox;
-		beforeEach(() => {
-			sandbox = sinon.sandbox.create();
-			sandbox.stub(window.d2lfetch, 'fetch', (input) => {
-				const whatToFetch = {
-					'/organizationAvailabilitySet.json': OrganizationAvailabilitySet.default,
-					'/organizationAvailabilitySetCannotAdd.json': OrganizationAvailabilitySet.cannotAdd,
-					'/organizationAvailabilitySetWithoutCurrentOrgUnit.json': OrganizationAvailabilitySet.withoutCurrentOrgUnit,
-					'/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json': OrganizationAvailabilitySet.cannotAddAndWithoutCurrentOrgUnit,
-					'/orgUnitAvailability1.json': OrgUnitAvailability.current,
-					'/orgUnitAvailability2.json': OrgUnitAvailability.explicit,
-					'/orgUnitAvailability3.json': OrgUnitAvailability.inherit,
-					'/orgUnitAvailability4.json': OrgUnitAvailability.inheritWithDescendentType,
-					'/organization6606.json': Organizations.Org6606
-				};
-				return Promise.resolve({
-					ok: true,
-					json: () => { return Promise.resolve(whatToFetch[input]); }
-				});
-			});
-
-			component = fixture('org-availability-set');
-		});
-
-		afterEach(() => {
-			sandbox.restore();
-		});
-
-		it('renders organization availability set', (done) => {
-			component.href = '/organizationAvailabilitySet.json';
-			afterNextRender(component, () => {
-				expect(component._availabilityEntities).to.have.lengthOf(3);
-				expect(component._currentOrgUnitEntity.class).to.include('current');
-				expect(component._canAddAvailability).to.be.true;
-				expect(component._currentOrgUnitName).to.equal('Dev');
-
-				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
-				expect(currentOrgUnitElems.length).to.equal(1);
-
-				const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
-				expect(availabilityElems.length).to.equal(3);
-
-				afterNextRender(component, () => {
-					const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
-					expect(buttonElems.length).to.equal(1);
-					expect(buttonElems[0].textContent.trim()).to.equal('Add Org Units');
-					done();
-				});
+	var component, sandbox;
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+			const whatToFetch = {
+				'/organizationAvailabilitySet.json': OrganizationAvailabilitySet.default,
+				'/organizationAvailabilitySetCannotAdd.json': OrganizationAvailabilitySet.cannotAdd,
+				'/organizationAvailabilitySetWithoutCurrentOrgUnit.json': OrganizationAvailabilitySet.withoutCurrentOrgUnit,
+				'/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json': OrganizationAvailabilitySet.cannotAddAndWithoutCurrentOrgUnit,
+				'/orgUnitAvailability1.json': OrgUnitAvailability.current,
+				'/orgUnitAvailability2.json': OrgUnitAvailability.explicit,
+				'/orgUnitAvailability3.json': OrgUnitAvailability.inherit,
+				'/orgUnitAvailability4.json': OrgUnitAvailability.inheritWithDescendentType,
+				'/organization6606.json': Organizations.Org6606
+			};
+			return Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(whatToFetch[input]); }
 			});
 		});
 
-		it('does not render Add Org Unit button when missing action', (done) => {
-			component.href = '/organizationAvailabilitySetCannotAdd.json';
-			afterNextRender(component, () => {
-				expect(component._canAddAvailability).to.be.false;
+		component = fixture('org-availability-set');
+	});
 
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('renders organization availability set', (done) => {
+		component.href = '/organizationAvailabilitySet.json';
+		afterNextRender(component, () => {
+			expect(component._availabilityEntities).to.have.lengthOf(3);
+			expect(component._currentOrgUnitEntity.class).to.include('current');
+			expect(component._canAddAvailability).to.be.true;
+			expect(component._currentOrgUnitName).to.equal('Dev');
+
+			const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+			expect(currentOrgUnitElems.length).to.equal(1);
+
+			const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
+			expect(availabilityElems.length).to.equal(3);
+
+			afterNextRender(component, () => {
 				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
-				expect(buttonElems.length).to.equal(0);
-
+				expect(buttonElems.length).to.equal(1);
+				expect(buttonElems[0].textContent.trim()).to.equal('Add Org Units');
 				done();
 			});
 		});
+	});
 
-		it('does not render current-organization-availability component if current org unit unchecked', (done) => {
-			component.href = '/organizationAvailabilitySetWithoutCurrentOrgUnit.json';
-			afterNextRender(component, () => {
-				expect(component._availabilityEntities).to.have.lengthOf(3);
-				expect(component._currentOrgUnitEntity).to.be.undefined;
-				expect(component._canAddAvailability).to.be.true;
+	it('does not render Add Org Unit button when missing action', (done) => {
+		component.href = '/organizationAvailabilitySetCannotAdd.json';
+		afterNextRender(component, () => {
+			expect(component._canAddAvailability).to.be.false;
 
-				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
-				expect(currentOrgUnitElems.length).to.equal(0);
+			const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+			expect(buttonElems.length).to.equal(0);
 
-				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
-				expect(checkboxElems.length).to.equal(1);
-				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
-
-				const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
-				expect(availabilityElems.length).to.equal(3);
-
-				done();
-			});
+			done();
 		});
+	});
 
-		it('does not render current-organization-availability component if current org unit unchecked and does not render Add Org Units button if action is missing', (done) => {
-			component.href = '/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json';
-			afterNextRender(component, () => {
-				expect(component._currentOrgUnitEntity).to.be.undefined;
-				expect(component._canAddAvailability).to.be.false;
+	it('does not render current-organization-availability component if current org unit unchecked', (done) => {
+		component.href = '/organizationAvailabilitySetWithoutCurrentOrgUnit.json';
+		afterNextRender(component, () => {
+			expect(component._availabilityEntities).to.have.lengthOf(3);
+			expect(component._currentOrgUnitEntity).to.be.undefined;
+			expect(component._canAddAvailability).to.be.true;
 
-				const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
-				expect(currentOrgUnitElems.length).to.equal(0);
+			const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+			expect(currentOrgUnitElems.length).to.equal(0);
 
-				const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
-				expect(checkboxElems.length).to.equal(1);
-				expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+			expect(checkboxElems.length).to.equal(1);
+			expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
 
-				const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
-				expect(buttonElems.length).to.equal(0);
+			const availabilityElems = component.shadowRoot.querySelectorAll('d2l-organization-availability');
+			expect(availabilityElems.length).to.equal(3);
 
-				done();
-			});
+			done();
+		});
+	});
+
+	it('does not render current-organization-availability component if current org unit unchecked and does not render Add Org Units button if action is missing', (done) => {
+		component.href = '/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json';
+		afterNextRender(component, () => {
+			expect(component._currentOrgUnitEntity).to.be.undefined;
+			expect(component._canAddAvailability).to.be.false;
+
+			const currentOrgUnitElems = component.shadowRoot.querySelectorAll('d2l-current-organization-availability');
+			expect(currentOrgUnitElems.length).to.equal(0);
+
+			const checkboxElems = component.shadowRoot.querySelectorAll('d2l-input-checkbox');
+			expect(checkboxElems.length).to.equal(1);
+			expect(checkboxElems[0].innerText.trim()).to.equal('Current Org Unit: Dev');
+
+			const buttonElems = component.shadowRoot.querySelectorAll('d2l-button');
+			expect(buttonElems.length).to.equal(0);
+
+			done();
 		});
 	});
 });

--- a/test/d2l-organization-availability-set/d2l-organization-availability.html
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.html
@@ -6,15 +6,15 @@
 		<script src="../../../wct-browser-legacy/browser.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-		<script type="module" src="../../components/d2l-organization-availability-set/d2l-organization-availability-set.js"></script>
+		<script type="module" src="../../components/d2l-organization-availability-set/d2l-organization-availability.js"></script>
 	</head>
 	<body>
-		<test-fixture id="org-availability-set">
+		<test-fixture id="org-availability">
 			<template>
-				<d2l-organization-availability-set token="whatever"></d2l-organization-availability-set>
+				<d2l-organization-availability token="whatever"></d2l-organization-availability>
 			</template>
 		</test-fixture>
 
-		<script type="module" src="./d2l-organization-availability-set.js"></script>
+		<script type="module" src="./d2l-organization-availability.js"></script>
 	</body>
 </html>

--- a/test/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.js
@@ -1,0 +1,75 @@
+import { Organizations, OrgUnitAvailability } from './data.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+
+window.D2L.Siren.WhitelistBehavior._testMode(true);
+
+describe('d2l-organization-availability', () => {
+	let sandbox;
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+			const whatToFetch = {
+				'/orgUnitAvailability2.json': OrgUnitAvailability.explicit,
+				'/orgUnitAvailability3.json': OrgUnitAvailability.inherit,
+				'/orgUnitAvailability4.json': OrgUnitAvailability.inheritWithDescendentType,
+				'/organization6606.json': Organizations.Org6606,
+				'/organization6609.json': Organizations.Org6609,
+				'/organization121147.json': Organizations.Org121147
+			};
+			return Promise.resolve({
+				ok: true,
+				json: () => { return Promise.resolve(whatToFetch[input]); }
+			});
+		});
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('explicit entity', () => {
+		let component;
+		before(() => {
+			component = fixture('org-availability');
+			component.href = '/orgUnitAvailability2.json';
+		});
+
+		it('renders organization availability set', (done) => {
+			afterNextRender(component, () => {
+				expect(component._name).to.equal('Course');
+				done();
+			});
+		});
+	});
+
+	describe('ineherit entity', () => {
+		let component;
+		before(() => {
+			component = fixture('org-availability');
+			component.href = '/orgUnitAvailability3.json';
+		});
+		it('renders organization availability set', (done) => {
+			afterNextRender(component, () => {
+				expect(component._name).to.equal('Accounting&Financial Management');
+				expect(component.textContent.trim()).to.equal("Every Org Unit in the Department: Accounting&Financial Management");
+				done();
+			});
+		});
+	});
+
+	describe('inherit with descendent type entity', () => {
+		let component;
+		before(() => {
+			component = fixture('org-availability');
+			component.href = '/orgUnitAvailability4.json';
+		});
+
+		it('renders organization availability set', (done) => {
+			afterNextRender(component, () => {
+				expect(component._name).to.equal('Accounting&Financial Management');
+				expect(component.textContent.trim()).to.equal("Every Program in the Department: Accounting&Financial Management");
+				done();
+			});
+		});
+	});
+});

--- a/test/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.js
@@ -42,16 +42,16 @@ describe('d2l-organization-availability', () => {
 		});
 	});
 
-	describe('ineherit entity', () => {
+	describe('inherit entity', () => {
 		let component;
 		before(() => {
 			component = fixture('org-availability');
 			component.href = '/orgUnitAvailability3.json';
 		});
+
 		it('renders organization availability set', (done) => {
 			afterNextRender(component, () => {
 				expect(component._name).to.equal('Accounting&Financial Management');
-				expect(component.textContent.trim()).to.equal("Every Org Unit in the Department: Accounting&Financial Management");
 				done();
 			});
 		});
@@ -67,7 +67,53 @@ describe('d2l-organization-availability', () => {
 		it('renders organization availability set', (done) => {
 			afterNextRender(component, () => {
 				expect(component._name).to.equal('Accounting&Financial Management');
-				expect(component.textContent.trim()).to.equal("Every Program in the Department: Accounting&Financial Management");
+				done();
+			});
+		});
+	});
+
+	describe('_renderItemDescription', () => {
+		let component;
+		before(() => {
+			component = fixture('org-availability');
+		});
+
+		it('handles explicit entity correctly', (done) => {
+			const entity = {
+				getCurrentTypeName: () => "Course Offering",
+				isExplicitAvailability: () => true
+			}
+			afterNextRender(component, () => {
+				const actualValue = component._renderItemDescription(entity, 'D2L Security');
+				expect(actualValue).to.equal('The Course Offering: D2L Security');
+				done();
+			});
+		});
+
+		it('handles inherit entity correctly', (done) => {
+			const entity = {
+				getCurrentTypeName: () => "Department",
+				isExplicitAvailability: () => false,
+				isInheritAvailability: () => true,
+				getDescendentTypeName: () => ""
+			}
+			afterNextRender(component, () => {
+				const actualValue = component._renderItemDescription(entity, 'Smart People');
+				expect(actualValue).to.equal('Every Org Unit under the Department: Smart People');
+				done();
+			});
+		});
+
+		it('handles inherit with descedent type entity correctly', (done) => {
+			const entity = {
+				getCurrentTypeName: () => "Organization",
+				isExplicitAvailability: () => false,
+				isInheritAvailability: () => true,
+				getDescendentTypeName: () => "Program"
+			}
+			afterNextRender(component, () => {
+				const actualValue = component._renderItemDescription(entity, 'D2L');
+				expect(actualValue).to.equal('Every Program under the Organization: D2L');
 				done();
 			});
 		});

--- a/test/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.js
@@ -83,11 +83,11 @@ describe('d2l-organization-availability', () => {
 				getCurrentTypeName: () => 'Course Offering',
 				isExplicitAvailability: () => true
 			};
-			afterNextRender(component, () => {
+			setTimeout(() => {
 				const actualValue = component._renderItemDescription(entity, 'D2L Security');
 				expect(actualValue).to.equal('The Course Offering: D2L Security');
 				done();
-			});
+			}, 200);
 		});
 
 		it('handles inherit entity correctly', (done) => {
@@ -97,11 +97,11 @@ describe('d2l-organization-availability', () => {
 				isInheritAvailability: () => true,
 				getDescendentTypeName: () => ''
 			};
-			afterNextRender(component, () => {
+			setTimeout(() => {
 				const actualValue = component._renderItemDescription(entity, 'Smart People');
 				expect(actualValue).to.equal('Every Org Unit under the Department: Smart People');
 				done();
-			});
+			}, 200);
 		});
 
 		it('handles inherit with descedent type entity correctly', (done) => {
@@ -111,11 +111,11 @@ describe('d2l-organization-availability', () => {
 				isInheritAvailability: () => true,
 				getDescendentTypeName: () => 'Program'
 			};
-			afterNextRender(component, () => {
+			setTimeout(() => {
 				const actualValue = component._renderItemDescription(entity, 'D2L');
 				expect(actualValue).to.equal('Every Program under the Organization: D2L');
 				done();
-			});
+			}, 200);
 		});
 	});
 });

--- a/test/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.js
@@ -80,9 +80,9 @@ describe('d2l-organization-availability', () => {
 
 		it('handles explicit entity correctly', (done) => {
 			const entity = {
-				getCurrentTypeName: () => "Course Offering",
+				getCurrentTypeName: () => 'Course Offering',
 				isExplicitAvailability: () => true
-			}
+			};
 			afterNextRender(component, () => {
 				const actualValue = component._renderItemDescription(entity, 'D2L Security');
 				expect(actualValue).to.equal('The Course Offering: D2L Security');
@@ -92,11 +92,11 @@ describe('d2l-organization-availability', () => {
 
 		it('handles inherit entity correctly', (done) => {
 			const entity = {
-				getCurrentTypeName: () => "Department",
+				getCurrentTypeName: () => 'Department',
 				isExplicitAvailability: () => false,
 				isInheritAvailability: () => true,
-				getDescendentTypeName: () => ""
-			}
+				getDescendentTypeName: () => ''
+			};
 			afterNextRender(component, () => {
 				const actualValue = component._renderItemDescription(entity, 'Smart People');
 				expect(actualValue).to.equal('Every Org Unit under the Department: Smart People');
@@ -106,11 +106,11 @@ describe('d2l-organization-availability', () => {
 
 		it('handles inherit with descedent type entity correctly', (done) => {
 			const entity = {
-				getCurrentTypeName: () => "Organization",
+				getCurrentTypeName: () => 'Organization',
 				isExplicitAvailability: () => false,
 				isInheritAvailability: () => true,
-				getDescendentTypeName: () => "Program"
-			}
+				getDescendentTypeName: () => 'Program'
+			};
 			afterNextRender(component, () => {
 				const actualValue = component._renderItemDescription(entity, 'D2L');
 				expect(actualValue).to.equal('Every Program under the Organization: D2L');

--- a/test/d2l-organization-availability-set/data.js
+++ b/test/d2l-organization-availability-set/data.js
@@ -133,7 +133,7 @@ export const OrganizationAvailabilitySet = {
 			'orgunit-availability-set'
 		],
 		'entities': [
-					{
+			{
 				'class': [
 					'orgunit-availability',
 					'explicit'

--- a/test/d2l-organization-availability-set/data.js
+++ b/test/d2l-organization-availability-set/data.js
@@ -1,0 +1,567 @@
+export const OrganizationAvailabilitySet = {
+	default: {
+		'class': [
+			'collection',
+			'orgunit-availability-set'
+		],
+		'entities': [
+			{
+				'class': [
+					'orgunit-availability',
+					'explicit',
+					'current'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability1.json'
+			},
+			{
+				'class': [
+					'orgunit-availability',
+					'explicit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability2.json'
+			},
+			{
+				'class': [
+					'orgunit-availability',
+					'inherit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability3.json'
+			},
+			{
+				'class': [
+					'orgunit-availability',
+					'inherit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability4.json'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organizationAvailabilitySet.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		],
+		'actions': [
+			{
+				'type': 'application/x-www-form-urlencoded',
+				'title': 'Create Explicit Availability Item',
+				'href': '/organizationAvailabilitySet.json',
+				'name': 'create-explicit-availability-item',
+				'method': 'POST',
+				'fields': [
+					{
+						'type': 'number',
+						'name': 'explicitOrgUnitId'
+					}
+				]
+			},
+			{
+				'type': 'application/x-www-form-urlencoded',
+				'title': 'Create Inherited Availability Item',
+				'href': '/organizationAvailabilitySet.json',
+				'name': 'create-inherited-availability-item',
+				'method': 'POST',
+				'fields': [
+					{
+						'type': 'number',
+						'name': 'ancestorOrgUnitId'
+					},
+					{
+						'type': 'number',
+						'name': 'descendentOrgUnitTypeId'
+					}
+				]
+			}
+		]
+	},
+	cannotAdd: {
+		'class': [
+			'collection',
+			'orgunit-availability-set'
+		],
+		'entities': [
+			{
+				'class': [
+					'orgunit-availability',
+					'explicit',
+					'current'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability1.json'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organizationAvailabilitySetCannotAdd.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		]
+	},
+	withoutCurrentOrgUnit: {
+		'class': [
+			'collection',
+			'orgunit-availability-set'
+		],
+		'entities': [
+					{
+				'class': [
+					'orgunit-availability',
+					'explicit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability2.json'
+			},
+			{
+				'class': [
+					'orgunit-availability',
+					'inherit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability3.json'
+			},
+			{
+				'class': [
+					'orgunit-availability',
+					'inherit'
+				],
+				'rel': [
+					'item'
+				],
+				'href': '/orgUnitAvailability4.json'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organizationAvailabilitySetWithoutCurrentOrgUnit.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		],
+		'actions': [
+			{
+				'type': 'application/x-www-form-urlencoded',
+				'title': 'Create Explicit Availability Item',
+				'href': '/organizationAvailabilitySet.json',
+				'name': 'create-explicit-availability-item',
+				'method': 'POST',
+				'fields': [
+					{
+						'type': 'number',
+						'name': 'explicitOrgUnitId'
+					}
+				]
+			},
+			{
+				'type': 'application/x-www-form-urlencoded',
+				'title': 'Create Inherited Availability Item',
+				'href': '/organizationAvailabilitySet.json',
+				'name': 'create-inherited-availability-item',
+				'method': 'POST',
+				'fields': [
+					{
+						'type': 'number',
+						'name': 'ancestorOrgUnitId'
+					},
+					{
+						'type': 'number',
+						'name': 'descendentOrgUnitTypeId'
+					}
+				]
+			}
+		]
+	},
+	cannotAddAndWithoutCurrentOrgUnit: {
+		'class': [
+			'collection',
+			'orgunit-availability-set'
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organizationAvailabilitySetCannotAddAndMissingCurrentOrgUnit.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		]
+	}
+};
+
+export const Organizations = {
+	Org6606: {
+		'class': [
+			'active',
+			'organization'
+		],
+		'properties': {
+			'name': 'Dev',
+			'code': null,
+			'startDate': null,
+			'endDate': null,
+			'isActive': true,
+			'description': null
+		},
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organization6606.json'
+			}
+		]
+	},
+	Org6609: {
+		'class': [
+			'active',
+			'course-offering'
+		],
+		'properties': {
+			'name': 'Course',
+			'code': 'C1',
+			'startDate': null,
+			'endDate': null,
+			'isActive': true,
+			'description': null
+		},
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organization6609.json'
+			}
+		]
+	},
+	Org121147: {
+		'class': [
+			'active',
+			'department'
+		],
+		'properties': {
+			'name': 'Accounting&Financial Management',
+			'code': 'AFM',
+			'startDate': null,
+			'endDate': null,
+			'isActive': true,
+			'description': null
+		},
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/organization121147.json'
+			}
+		]
+	}
+};
+
+export const OrgUnitAvailability = {
+	current: {
+		'class': [
+			'orgunit-availability',
+			'explicit',
+			'current'
+		],
+		'rel': [
+			'https://api.brightspace.com/rels/cache-primer'
+		],
+		'entities': [
+			{
+				'class': [
+					'current',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Organization'
+				}
+			}
+		],
+		'actions': [
+			{
+				'title': 'Delete Item',
+				'href': '/orgUnitAvailability1.json',
+				'name': 'delete-item',
+				'method': 'DELETE'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/orgUnitAvailability1.json'
+			},
+			{
+				'rel': [
+					'collection'
+				],
+				'href': '/organizationAvailabilitySet.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		]
+	},
+	currentCannotDelete: {
+		'class': [
+			'orgunit-availability',
+			'explicit',
+			'current'
+		],
+		'rel': [
+			'https://api.brightspace.com/rels/cache-primer'
+		],
+		'entities': [
+			{
+				'class': [
+					'current',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Organization'
+				}
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/orgUnitAvailability5.json'
+			},
+			{
+				'rel': [
+					'collection'
+				],
+				'href': '/fakehref'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6606.json'
+			}
+		]
+	},
+	explicit: {
+		'class': [
+			'orgunit-availability',
+			'explicit'
+		],
+		'rel': [
+			'https://api.brightspace.com/rels/cache-primer'
+		],
+		'entities': [
+			{
+				'class': [
+					'current',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Course Offering'
+				}
+			}
+		],
+		'actions': [
+			{
+				'title': 'Delete Item',
+				'href': '/orgUnitAvailability2.json',
+				'name': 'delete-item',
+				'method': 'DELETE'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/orgUnitAvailability2.json'
+			},
+			{
+				'rel': [
+					'collection'
+				],
+				'href': '/organizationAvailabilitySet.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization6609.json'
+			}
+		]
+	},
+	inherit: {
+		'class': [
+			'orgunit-availability',
+			'inherit'
+		],
+		'rel': [
+			'https://api.brightspace.com/rels/cache-primer'
+		],
+		'entities': [
+			{
+				'class': [
+					'current',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Department'
+				}
+			}
+		],
+		'actions': [
+			{
+				'title': 'Delete Item',
+				'href': '/orgUnitAvailability3.json',
+				'name': 'delete-item',
+				'method': 'DELETE'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/orgUnitAvailability3.json'
+			},
+			{
+				'rel': [
+					'collection'
+				],
+				'href': '/organizationAvailabilitySet.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization121147.json'
+			}
+		]
+	},
+	inheritWithDescendentType: {
+		'class': [
+			'orgunit-availability',
+			'inherit'
+		],
+		'rel': [
+			'https://api.brightspace.com/rels/cache-primer'
+		],
+		'entities': [
+			{
+				'class': [
+					'descendent',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Program'
+				}
+			},
+			{
+				'class': [
+					'current',
+					'orgunit-type'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/organization-type'
+				],
+				'properties': {
+					'name': 'Department'
+				}
+			}
+		],
+		'actions': [
+			{
+				'title': 'Delete Item',
+				'href': '/orgUnitAvailability4.json',
+				'name': 'delete-item',
+				'method': 'DELETE'
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': '/orgUnitAvailability4.json'
+			},
+			{
+				'rel': [
+					'collection'
+				],
+				'href': '/organizationAvailabilitySet.json'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': '/organization121147.json'
+			}
+		]
+	}
+};

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,9 @@
 	<body>
 		<script>
 			WCT.loadSuites([
+				'./d2l-organization-availability-set/d2l-current-organization-availability.html',
+				'./d2l-organization-availability-set/d2l-organization-availability-set.html',
+				'./d2l-organization-availability-set/d2l-organization-availability.html',
 				'./d2l-organization-consortium/d2l-organization-consortium.html',
 				'./d2l-organization-date/d2l-organization-date.html',
 				'./d2l-organization-detail-card/d2l-organization-detail-card.html',


### PR DESCRIPTION
Uses siren-sdk changes here: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/79

- calls availabilitySetCollection API and cache-primer
- renders availability set list with properly formatted type description (e.g. The Course Offering xyz, The Department xyz, Every Program under the Department xyz, Every Org Unit under the Course Template xyz)
- renders "Current Org Unit: xyz" with checkbox in correct checked/unchecked state and with correct enabled/disabled state based on siren actions.
- show/hide "Add Org Units" button when appropriate
