### PR TITLE
US111920 - Remove notification dot from selected tab

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -214,7 +214,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<template is="dom-if" if="[[!item.loading]]">
 						<a class="d2l-consortium-tab" id$="[[item.id]]" href$="[[_getTabHref(item)]]" aria-label$="[[_getTabAriaLabel(item)]]"><div class="d2l-consortium-tab-content">[[item.name]]</div></a>
-						<d2l-navigation-notification-icon hidden$="[[!item.hasNotification]]" thin-border></d2l-navigation-notification-icon>
+						<d2l-navigation-notification-icon hidden$="[[!_checkOrgNotification(item)]]" thin-border></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">
 						<div class="d2l-consortium-tab" id$="[[item.id]]">
@@ -418,13 +418,16 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 		return this._isSelected(item) ? undefined : item.href;
 	}
 	_getTabAriaLabel(item) {
-		return item.hasNotification ? this.localize('newNotifications', 'name', item.fullName) : item.fullName;
+		return this._checkOrgNotification(item) ? this.localize('newNotifications', 'name', item.fullName) : item.fullName;
 	}
 	_hasErrors(errors) {
 		return errors.length > 0;
 	}
+	_checkOrgNotification(org) {
+		return org.hasNotification && !this._isSelected(org);
+	}
 	_checkNotifications(orgs) {
-		const nowHasNotifications = orgs.value.some((org) => { return org.hasNotification; });
+		const nowHasNotifications = orgs.value.some((org) => { return this._checkOrgNotification(org); });
 
 		if (this._hasNotifications === nowHasNotifications) {
 			return;

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -223,6 +223,18 @@ describe('d2l-organization-consortium-tabs', function() {
 			});
 		});
 
+		it('selected tab does not show the notification dot', function(done) {
+			const component = fixture('org-consortium');
+			component.href = '/consortium-root1.json';
+			component.selected = '1cb16d6a-8557-4850-8846-3fa9b6174494';
+
+			afterNextRender(component, function() {
+				const selectedTab = component.shadowRoot.querySelector('.d2l-tab-container[selected]');
+				assert.isTrue(selectedTab.querySelector('d2l-navigation-notification-icon').hidden);
+				done();
+			});
+		});
+
 		it('alerts use correct token', function(done) {
 			const component = fixture('org-consortium');
 			component.href = '/consortium-root1.json';
@@ -286,6 +298,20 @@ describe('d2l-organization-consortium-tabs', function() {
 				}
 			});
 			component.href = '/consortium-root1.json';
+		});
+
+		it('d2l-organization-consortium-tabs-notification-update event is not fired if the only notification is on the selected tab', function(done) {
+			const component = fixture('org-consortium');
+			component.addEventListener('d2l-organization-consortium-tabs-notification-update', function() {
+				assert.isOk(false, 'd2l-organization-consortium-tabs-notification-update event should not have been fired.');
+			});
+
+			component.href = '/consortium-root1.json';
+			component.selected = '1cb16d6a-8557-4850-8846-3fa9b6174494';
+
+			afterNextRender(component, function() {
+				done();
+			});
 		});
 	});
 


### PR DESCRIPTION
This is in response to an issue Minnstate had when testing.  After they clear the notification from the navbar, it won't go away in the org tab until we poll again (up to five minutes later), they refresh the page, or they navigate to a new page.

Instead of hooking up an event system to tell the tabs to re-poll early, we decided to remove the notification dot on the selected tab altogether.  You also won't see a notification dot on the hamburger icon of the mobile menu if the tab you are on is the only one with a notification