### PR TITLE
US111258 - Add ability for the requestScroll function to request retry

### DIFF
--- a/demo/d2l-organization-consortium/d2l-organization-consortium.html
+++ b/demo/d2l-organization-consortium/d2l-organization-consortium.html
@@ -137,8 +137,10 @@ Ground round meatball spare ribs filet mignon corned beef shankle alcatra tongue
 			document.querySelector('#tabs-2').selected = new URLSearchParams(window.location.search).get('consortium') || '1cb16d6a-8557-4850-8846-3fa9b6174494';
 			document.querySelector('#tabs-3').selected = new URLSearchParams(window.location.search).get('consortium') || '1cb16d6a-8557-4850-8846-3fa9b6174494';
 			document.querySelector('#show-org-tabs').addEventListener('click', function showOrgTabs() {
-				document.querySelector('d2l-navigation-band[hidden]').removeAttribute('hidden');
-				document.querySelector('#tabs-2').tryRequestScroll();
+				document.querySelector('#tabs-2').requestScroll(true);
+				setTimeout(() => {
+					document.querySelector('d2l-navigation-band[hidden]').removeAttribute('hidden');
+				}, 200);
 				document.querySelector('#show-org-tabs').removeEventListener('click', showOrgTabs);
 			});
 			document.querySelector('#tabs-3').token = tokenGetter;

--- a/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/test/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -317,10 +317,10 @@ describe('d2l-organization-consortium-tabs', function() {
 
 			component.addEventListener('d2l-navigation-band-slot-scroll-request', function() {
 				assert.equal(Object.keys(component._organizations).filter(key => component._organizations[key].loading), 0);
-				assert.isNumber(component._requestedScrollTimeoutId);
+				assert.isNumber(component._sendScrollRequestTimeoutId);
 				done();
 			});
-			assert.isUndefined(component._requestedScrollTimeoutId);
+			assert.isUndefined(component._sendScrollRequestTimeoutId);
 			component.selected = '8b33e567-c616-4667-868b-fdfe9edc3a78';
 			component.href = '/consortium-root1.json';
 		});


### PR DESCRIPTION
Related to Dave's comment here: https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/6035/overview

How does everyone feel about this?  About half of this PR is renaming functions and properties to try to make things clearer, and the other half is adding a parameter to the public scroll function to request that it retry if the width is still set to 0.

I updated the demo page to test that this actually works, because with the addition of the fastdom call, the LMS doesn't even need the `setTimeout` in the monolith anymore.  Jeff seemed ok with either (leaving as is, knowing there's a chance the scroll is missed, or doing this polling).