### PR TITLE
Fix trying to localize before localization resources are loaded

### DIFF
--- a/components/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -54,10 +54,14 @@ class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitEl
 		}
 	}
 
+	get _itemDescription() {
+		return this.localize('currentOrgUnitItemDescription', { name: this._name })
+	}
+
 	render() {
 		return html`
 			<d2l-input-checkbox checked ?disabled="${!this._canDelete}">
-				${this.localize('currentOrgUnitItemDescription', { name: this._name })}
+				${this._itemDescription}
 			</d2l-input-checkbox>
 		`;
 	}

--- a/components/d2l-organization-availability-set/d2l-current-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-current-organization-availability.js
@@ -55,7 +55,7 @@ class CurrentOrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitEl
 	}
 
 	get _itemDescription() {
-		return this.localize('currentOrgUnitItemDescription', { name: this._name })
+		return this.localize('currentOrgUnitItemDescription', { name: this._name });
 	}
 
 	render() {

--- a/components/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability.js
@@ -104,12 +104,13 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 	}
 
 	render() {
+		const itemDescription = this._itemDescription;
 		return html`
-			${this._itemDescription}
-			${this._itemDescription && this._canDelete ? html`
+			${itemDescription}
+			${itemDescription && this._canDelete ? html`
 				<d2l-button-icon
 					?disabled="${this._isDeleting}"
-					text="${this.localize('removeAvailabilityFor', { itemDescription: this._itemDescription })}"
+					text="${this.localize('removeAvailabilityFor', { itemDescription })}"
 					icon="tier1:close-default"
 					@click="${this._delete}"></d2l-button-icon>
 			` : ''}

--- a/components/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/components/d2l-organization-availability-set/d2l-organization-availability.js
@@ -12,7 +12,6 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 		return {
 			_canDelete: { type: Boolean },
 			_name: { type: String },
-			_itemDescription: { type: String },
 			_isDeleting: { type: Boolean }
 		};
 	}
@@ -37,6 +36,10 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 		this._setEntityType(OrganizationAvailabilityEntity);
 	}
 
+	get _entity() {
+		return super._entity;
+	}
+
 	set _entity(entity) {
 		if (this._entityHasChanged(entity)) {
 			this._onAvailabilityChange(entity);
@@ -55,28 +58,8 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 		if (entity) {
 			entity.onOrganizationChange(organization => {
 				this._name = organization.name();
-				this._itemDescription = this._generateItemDescription(entity, this._name);
 			});
 		}
-	}
-
-	_generateItemDescription(entity, name) {
-		if (entity && name) {
-			const type = entity.getCurrentTypeName();
-
-			if (entity.isExplicitAvailability()) {
-				return this.localize('explicitItemDescription', { type, name });
-			}
-
-			if (entity.isInheritAvailability()) {
-				const descendantType = entity.getDescendantTypeName();
-				if (descendantType) {
-					return this.localize('inheritItemWithDescendantTypeDescription', { type, name, descendantType });
-				}
-				return this.localize('inheritItemDescription', { type, name });
-			}
-		}
-		return '';
 	}
 
 	_delete() {
@@ -98,6 +81,26 @@ class OrganizationAvailability extends EntityMixinLit(LocalizeMixin(LitElement))
 				detail: { promise }
 			})
 		);
+	}
+
+	get _itemDescription() {
+		const entity = this._entity;
+		const name = this._name;
+		if (entity && name) {
+			const type = entity.getCurrentTypeName();
+			if (entity.isExplicitAvailability()) {
+				return this.localize('explicitItemDescription', { type, name });
+			}
+
+			if (entity.isInheritAvailability()) {
+				const descendantType = entity.getDescendantTypeName();
+				if (descendantType) {
+					return this.localize('inheritItemWithDescendantTypeDescription', { type, name, descendantType });
+				}
+				return this.localize('inheritItemDescription', { type, name });
+			}
+		}
+		return '';
 	}
 
 	render() {

--- a/test/d2l-organization-availability-set/d2l-organization-availability.js
+++ b/test/d2l-organization-availability-set/d2l-organization-availability.js
@@ -29,14 +29,20 @@ describe('d2l-organization-availability', () => {
 
 	describe('explicit entity', () => {
 		let component;
+
 		before(() => {
 			component = fixture('org-availability');
 			component.href = '/orgUnitAvailability2.json';
+
+			sinon.stub(component, 'localize')
+				.withArgs('explicitItemDescription', { type: 'Course Offering', name: 'Course' })
+				.returns('Explicit Item Description');
 		});
 
 		it('renders organization availability set', (done) => {
 			afterNextRender(component, () => {
 				expect(component._name).to.equal('Course');
+				expect(component._itemDescription).to.equal('Explicit Item Description');
 				done();
 			});
 		});
@@ -44,14 +50,20 @@ describe('d2l-organization-availability', () => {
 
 	describe('inherit entity', () => {
 		let component;
+
 		before(() => {
 			component = fixture('org-availability');
 			component.href = '/orgUnitAvailability3.json';
+
+			sinon.stub(component, 'localize')
+				.withArgs('inheritItemDescription', { type: 'Department', name: 'Accounting&Financial Management' })
+				.returns('Inherit Item Description');
 		});
 
 		it('renders organization availability set', (done) => {
 			afterNextRender(component, () => {
 				expect(component._name).to.equal('Accounting&Financial Management');
+				expect(component._itemDescription).to.equal('Inherit Item Description');
 				done();
 			});
 		});
@@ -59,63 +71,22 @@ describe('d2l-organization-availability', () => {
 
 	describe('inherit with descendant type entity', () => {
 		let component;
+
 		before(() => {
 			component = fixture('org-availability');
 			component.href = '/orgUnitAvailability4.json';
+
+			sinon.stub(component, 'localize')
+				.withArgs('inheritItemWithDescendantTypeDescription', { type: 'Department', name: 'Accounting&Financial Management', descendantType: 'Program' })
+				.returns('Inherit with descendant type Item Description');
 		});
 
 		it('renders organization availability set', (done) => {
 			afterNextRender(component, () => {
 				expect(component._name).to.equal('Accounting&Financial Management');
+				expect(component._itemDescription).to.equal('Inherit with descendant type Item Description');
 				done();
 			});
-		});
-	});
-
-	describe('_generateItemDescription', () => {
-		let component;
-		before(() => {
-			component = fixture('org-availability');
-		});
-
-		it('handles explicit entity correctly', (done) => {
-			const entity = {
-				getCurrentTypeName: () => 'Course Offering',
-				isExplicitAvailability: () => true
-			};
-			setTimeout(() => {
-				const actualValue = component._generateItemDescription(entity, 'D2L Security');
-				expect(actualValue).to.equal('The Course Offering: D2L Security');
-				done();
-			}, 200);
-		});
-
-		it('handles inherit entity correctly', (done) => {
-			const entity = {
-				getCurrentTypeName: () => 'Department',
-				isExplicitAvailability: () => false,
-				isInheritAvailability: () => true,
-				getDescendantTypeName: () => ''
-			};
-			setTimeout(() => {
-				const actualValue = component._generateItemDescription(entity, 'Smart People');
-				expect(actualValue).to.equal('Every Org Unit under the Department: Smart People');
-				done();
-			}, 200);
-		});
-
-		it('handles inherit with descedent type entity correctly', (done) => {
-			const entity = {
-				getCurrentTypeName: () => 'Organization',
-				isExplicitAvailability: () => false,
-				isInheritAvailability: () => true,
-				getDescendantTypeName: () => 'Program'
-			};
-			setTimeout(() => {
-				const actualValue = component._generateItemDescription(entity, 'D2L');
-				expect(actualValue).to.equal('Every Program under the Organization: D2L');
-				done();
-			}, 200);
 		});
 	});
 });


### PR DESCRIPTION
Some timing issue. What happens in the function trying to localize our item descriptions is called before the `shouldUpdate` method in the localize-mixin happens, which is where the language resources are loaded. So we end up trying to localize and it sees no language files and fails silently.