### PR TITLE
US111492 - Remove focus styles when clicking a tab

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -184,6 +184,9 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 				word-break: break-all;
 				vertical-align: middle;
 			}
+			.d2l-consortium-tab-content:focus {
+				outline: none;
+			}
 			[selected] .d2l-consortium-tab-content {
 				color: var(--d2l-color-ferrite);
 				cursor: default;
@@ -217,7 +220,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 			<template items="[[_parsedOrganizations]]" is="dom-repeat" sort="_sortOrder" >
 				<div class="d2l-tab-container" selected$="[[_isSelected(item)]]">
 					<template is="dom-if" if="[[!item.loading]]">
-						<a class="d2l-consortium-tab" id$="[[item.id]]" href$="[[_getTabHref(item)]]" aria-label$="[[_getTabAriaLabel(item)]]"><div class="d2l-consortium-tab-content">[[item.name]]</div></a>
+						<a class="d2l-consortium-tab" id$="[[item.id]]" href$="[[_getTabHref(item)]]" aria-label$="[[_getTabAriaLabel(item)]]"><div class="d2l-consortium-tab-content" tabindex="-1">[[item.name]]</div></a>
 						<d2l-navigation-notification-icon hidden$="[[!_checkOrgNotification(item)]]" thin-border></d2l-navigation-notification-icon>
 					</template>
 					<template is="dom-if" if="[[item.loading]]">


### PR DESCRIPTION
So after investigating, the polyfill for `focus-visible` seems a bit scary perf-wise, a trimmed-down org-tabs specific polyfill was seen as undesirable, and the current implementation of `:-moz-focusring` is buggy.
I found another suggestion that actually works out super nicely for our use-case, and wanted to put it up to see if anyone can think of unwanted side effects.  What I'm doing is adding `tabindex="-1"` to the inner element inside the link.  This causes a click to focus on that element and use its focus styles (none), whereas a tab focuses on the outer `a` element (where the focus styles live).  This works perfectly on Chrome, Edge and Firefox, and I tested all three with NVDA and it doesn't interpret this any differently from what I can tell.  Would be good to test on VoiceOver as well if no one has any other concerns with this approach!