### PR TITLE
Add the d2l-organization-admin-list component

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
@@ -1,0 +1,111 @@
+import { css, html, LitElement } from "lit-element/lit-element.js";
+import "@brightspace-ui/core/components/button/button.js";
+import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+
+class AdminListPager extends LocalizeMixin(LitElement) {
+	static get properties() {
+		return {
+			totalPages: {
+				type: Number
+			},
+			currentPage: {
+				type: Number
+			},
+			onPageChanged: {
+				type: Function
+			}
+		};
+	}
+
+	static get styles() {
+		return [
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+
+				.d2l-organization-admin-list-pager {
+					margin: 15px;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				}
+				.d2l-organization-admin-list-pager-count {
+					width: auto;
+					max-width: 4rem;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this.currentPage = 1;
+		this.totalPages = 1;
+	}
+
+	_hasPreviousPage() {
+		return this.currentPage > 1;
+	}
+
+	_hasNextPage() {
+		return this.currentPage < this.totalPages;
+	}
+
+	_toPreviousPage() {
+		this.onPageChanged(this.currentPage - 1);
+	}
+
+	_toNextPage() {
+		this.onPageChanged(this.currentPage + 1);
+	}
+
+	_toPage(e) {
+		this.onPageChanged(e.target.value);
+	} 
+
+	_countDigits(number) {
+		return number.toString().length;
+	}
+
+	render() {
+		return html`
+            <div class="d2l-organization-admin-list-pager">
+                <d2l-button-icon
+                    icon="d2l-tier1:chevron-left"
+					aria-label=${this.localize("pagePrevious")}
+                    .disabled=${!this._hasPreviousPage()}
+                    @click=${this._toPreviousPage}
+                >
+                </d2l-button-icon>
+                <d2l-input-text
+                    class="d2l-organization-admin-list-pager-count"
+                    type="number"
+                    aria-label=${this.localize("pageSelection", {'pageCurrent': this.currentPage, 'pageTotal': this.totalPages})}
+                    name="pageInput"
+                    value=${this.currentPage}
+                    min="1"
+                    max=${this.totalPages}
+					size=${this._countDigits(this.totalPages)}
+					@change=${this._toPage}
+                >
+                </d2l-input-text>
+                <div>&nbsp/&nbsp${this.totalPages}</div>
+				<d2l-button-icon
+					icon="d2l-tier1:chevron-right"
+					aria-label=${this.localize("pageNext")}
+					.disabled=${!this._hasNextPage()}
+					@click=${this._toNextPage}
+				>
+				</d2l-button-icon>
+			</div>
+		`;
+	}
+}
+customElements.define(
+	"d2l-organization-admin-list-pager",
+	AdminListPager
+);

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from "lit-element/lit-element.js";
 import "@brightspace-ui/core/components/button/button.js";
 import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+import { getLocalizeResources } from "./localization.js";
 
 class AdminListPager extends LocalizeMixin(LitElement) {
 	static get properties() {
@@ -41,6 +42,10 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 		];
 	}
 
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
 	constructor() {
 		super();
 		this.currentPage = 1;
@@ -65,7 +70,7 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 
 	_toPage(e) {
 		this.onPageChanged(e.target.value);
-	} 
+	}
 
 	_countDigits(number) {
 		return number.toString().length;
@@ -73,27 +78,30 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 
 	render() {
 		return html`
-            <div class="d2l-organization-admin-list-pager">
-                <d2l-button-icon
-                    icon="d2l-tier1:chevron-left"
+			<div class="d2l-organization-admin-list-pager">
+				<d2l-button-icon
+					icon="d2l-tier1:chevron-left"
 					aria-label=${this.localize("pagePrevious")}
-                    .disabled=${!this._hasPreviousPage()}
-                    @click=${this._toPreviousPage}
-                >
-                </d2l-button-icon>
-                <d2l-input-text
-                    class="d2l-organization-admin-list-pager-count"
-                    type="number"
-                    aria-label=${this.localize("pageSelection", {'pageCurrent': this.currentPage, 'pageTotal': this.totalPages})}
-                    name="pageInput"
-                    value=${this.currentPage}
-                    min="1"
-                    max=${this.totalPages}
+					.disabled=${!this._hasPreviousPage()}
+					@click=${this._toPreviousPage}
+				>
+				</d2l-button-icon>
+				<d2l-input-text
+					class="d2l-organization-admin-list-pager-count"
+					type="number"
+					aria-label=${this.localize("pageSelection", {
+						pageCurrent: this.currentPage,
+						pageTotal: this.totalPages
+					})}
+					name="pageInput"
+					value=${this.currentPage}
+					min="1"
+					max=${this.totalPages}
 					size=${this._countDigits(this.totalPages)}
 					@change=${this._toPage}
-                >
-                </d2l-input-text>
-                <div>&nbsp/&nbsp${this.totalPages}</div>
+				>
+				</d2l-input-text>
+				<div>&nbsp/&nbsp${this.totalPages}</div>
 				<d2l-button-icon
 					icon="d2l-tier1:chevron-right"
 					aria-label=${this.localize("pageNext")}

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
@@ -1,7 +1,8 @@
+import "@brightspace-ui/core/components/button/button-icon.js";
+import "@brightspace-ui/core/components/inputs/input-text.js";
 import { css, html, LitElement } from "lit-element/lit-element.js";
-import "@brightspace-ui/core/components/button/button.js";
-import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
 import { getLocalizeResources } from "./localization.js";
+import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
 
 class AdminListPager extends LocalizeMixin(LitElement) {
 	static get properties() {
@@ -29,14 +30,14 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 				}
 
 				.d2l-organization-admin-list-pager {
-					margin: 15px;
-					display: flex;
 					align-items: center;
+					display: flex;
 					justify-content: center;
+					margin: 15px;
 				}
 				.d2l-organization-admin-list-pager-count {
-					width: auto;
 					max-width: 4rem;
+					width: auto;
 				}
 			`
 		];

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
@@ -1,8 +1,8 @@
-import "@brightspace-ui/core/components/button/button-icon.js";
-import "@brightspace-ui/core/components/inputs/input-text.js";
-import { css, html, LitElement } from "lit-element/lit-element.js";
-import { getLocalizeResources } from "./localization.js";
-import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { getLocalizeResources } from './localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 class AdminListPager extends LocalizeMixin(LitElement) {
 	static get properties() {
@@ -79,24 +79,21 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 
 	render() {
 		return html`
-			<div class="d2l-organization-admin-list-pager">
+			<div class='d2l-organization-admin-list-pager'>
 				<d2l-button-icon
-					icon="d2l-tier1:chevron-left"
-					aria-label=${this.localize("pagePrevious")}
+					icon='d2l-tier1:chevron-left'
+					aria-label=${this.localize('pagePrevious')}
 					.disabled=${!this._hasPreviousPage()}
 					@click=${this._toPreviousPage}
 				>
 				</d2l-button-icon>
 				<d2l-input-text
-					class="d2l-organization-admin-list-pager-count"
-					type="number"
-					aria-label=${this.localize("pageSelection", {
-						pageCurrent: this.currentPage,
-						pageTotal: this.totalPages
-					})}
-					name="pageInput"
+					class='d2l-organization-admin-list-pager-count'
+					type='number'
+					aria-label=${this.localize('pageSelection', { pageCurrent: this.currentPage, pageTotal: this.totalPages })}
+					name='pageInput'
 					value=${this.currentPage}
-					min="1"
+					min='1'
 					max=${this.totalPages}
 					size=${this._countDigits(this.totalPages)}
 					@change=${this._toPage}
@@ -104,8 +101,8 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 				</d2l-input-text>
 				<div>&nbsp/&nbsp${this.totalPages}</div>
 				<d2l-button-icon
-					icon="d2l-tier1:chevron-right"
-					aria-label=${this.localize("pageNext")}
+					icon='d2l-tier1:chevron-right'
+					aria-label=${this.localize('pageNext')}
 					.disabled=${!this._hasNextPage()}
 					@click=${this._toNextPage}
 				>
@@ -115,6 +112,6 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 	}
 }
 customElements.define(
-	"d2l-organization-admin-list-pager",
+	'd2l-organization-admin-list-pager',
 	AdminListPager
 );

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from "lit-element/lit-element.js";
 import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+import { getLocalizeResources } from "./localization.js";
 
 class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 	static get properties() {
@@ -36,20 +37,25 @@ class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 		];
 	}
 
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
 	constructor() {
 		super();
 		this._searchText = "";
-    }
-    
-    _handleSearch(e) {
-        if (e && e.detail) {
-            const searchText = e.detail.value;
-            if (searchText !== this._searchText) {
-				this.onSearchTextChanged && this.onSearchTextChanged(searchText);
-                this._searchText = searchText;
-            }
-        }
-    }
+	}
+
+	_handleSearch(e) {
+		if (e && e.detail) {
+			const searchText = e.detail.value;
+			if (searchText !== this._searchText) {
+				this.onSearchTextChanged &&
+					this.onSearchTextChanged(searchText);
+				this._searchText = searchText;
+			}
+		}
+	}
 
 	render() {
 		return html`

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
@@ -1,7 +1,7 @@
-import "@brightspace-ui/core/components/inputs/input-search.js";
-import { css, html, LitElement } from "lit-element/lit-element.js";
-import { getLocalizeResources } from "./localization.js";
-import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+import '@brightspace-ui/core/components/inputs/input-search.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { getLocalizeResources } from './localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 	static get properties() {
@@ -44,7 +44,7 @@ class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 
 	constructor() {
 		super();
-		this._searchText = "";
+		this._searchText = '';
 	}
 
 	_handleSearch(e) {
@@ -60,12 +60,12 @@ class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 
 	render() {
 		return html`
-			<div class="d2l-organization-admin-list-search-header-container">
+			<div class='d2l-organization-admin-list-search-header-container'>
 				<d2l-input-search
-					class="d2l-organization-admin-list-search-header-input"
-					label=${this.localize("search")}
+					class='d2l-organization-admin-list-search-header-input'
+					label=${this.localize('search')}
 					value=${this._searchText}
-					placeholder=${this.localize("searchPlaceholder")}
+					placeholder=${this.localize('searchPlaceholder')}
 					@d2l-input-search-searched=${this._handleSearch}
 				>
 				</d2l-input-search>
@@ -74,6 +74,6 @@ class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 	}
 }
 customElements.define(
-	"d2l-organization-admin-list-search-header",
+	'd2l-organization-admin-list-search-header',
 	AdminListSearchHeader
 );

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
@@ -1,6 +1,7 @@
+import "@brightspace-ui/core/components/inputs/input-search.js";
 import { css, html, LitElement } from "lit-element/lit-element.js";
-import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
 import { getLocalizeResources } from "./localization.js";
+import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
 
 class AdminListSearchHeader extends LocalizeMixin(LitElement) {
 	static get properties() {

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-search-header.js
@@ -1,0 +1,72 @@
+import { css, html, LitElement } from "lit-element/lit-element.js";
+import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
+
+class AdminListSearchHeader extends LocalizeMixin(LitElement) {
+	static get properties() {
+		return {
+			onSearchTextChanged: {
+				type: Function
+			},
+			_searchText: {
+				type: String
+			}
+		};
+	}
+
+	static get styles() {
+		return [
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+
+				.d2l-organization-admin-list-search-header-container {
+					display: flex;
+					justify-content: space-between;
+					margin: 12px 0;
+				}
+
+				.d2l-organization-admin-list-search-header-input {
+					width: 270px;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._searchText = "";
+    }
+    
+    _handleSearch(e) {
+        if (e && e.detail) {
+            const searchText = e.detail.value;
+            if (searchText !== this._searchText) {
+				this.onSearchTextChanged && this.onSearchTextChanged(searchText);
+                this._searchText = searchText;
+            }
+        }
+    }
+
+	render() {
+		return html`
+			<div class="d2l-organization-admin-list-search-header-container">
+				<d2l-input-search
+					class="d2l-organization-admin-list-search-header-input"
+					label=${this.localize("search")}
+					value=${this._searchText}
+					placeholder=${this.localize("searchPlaceholder")}
+					@d2l-input-search-searched=${this._handleSearch}
+				>
+				</d2l-input-search>
+			</div>
+		`;
+	}
+}
+customElements.define(
+	"d2l-organization-admin-list-search-header",
+	AdminListSearchHeader
+);

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -39,7 +39,7 @@ class AdminList extends EntityMixinLit(LitElement) {
 				}
 				.d2l-organization-admin-list-content {
 					box-sizing: border-box;
-					padding: 0 30px;
+					padding: 0 2.439%;
 					max-width: 1230px;
 					width: 100%;
 				}
@@ -47,13 +47,15 @@ class AdminList extends EntityMixinLit(LitElement) {
 				.d2l-organization-admin-list-header-container {
 					border-bottom: solid 1px var(--d2l-color-gypsum);
 					box-sizing: border-box;
-					height: 96px;
 					width: 100%;
 				}
 				.d2l-organization-admin-list-header {
 					align-items: center;
 					display: flex;
 					justify-content: space-between;
+				}
+				.d2l-organization-admin-list-title {
+					margin: 24px 0;
 				}
 
 				.d2l-organization-admin-list-background-gradient {
@@ -86,6 +88,30 @@ class AdminList extends EntityMixinLit(LitElement) {
 				.d2l-organization-admin-list-search-results-page-count {
 					width: auto;
 					max-width: 4rem;
+				}
+
+				@media (max-width: 420px) {
+					.d2l-organization-admin-list-header {
+						flex-direction: column;
+						justify-content: flex-start;
+						align-items: flex-start;
+					}
+					.d2l-organization-admin-list-create-button {
+						width: 100%;
+						margin-bottom: 24px;
+					}
+				}
+
+				@media (max-width: 615px) {
+					.d2l-organization-admin-list-content {
+						padding: 0 15px;
+					}
+				}
+
+				@media (min-width: 1230px) {
+					.d2l-organization-admin-list-content {
+						padding: 0 30px;
+					}
 				}
 			`
 		];
@@ -150,8 +176,8 @@ class AdminList extends EntityMixinLit(LitElement) {
 		return html`
 			<div class="d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container">
 				<div class="d2l-organization-admin-list-content d2l-organization-admin-list-header">
-					<h1 class="d2l-heading-1">${this["title-text"]}</h1>
-					<d2l-button primary>Create Learning Path</d2l-button>
+					<h1 class="d2l-heading-1 d2l-organization-admin-list-title">${this["title-text"]}</h1>
+					<d2l-button class="d2l-organization-admin-list-create-button" primary>Create Learning Path</d2l-button>
 				</div>
 			</div>
 

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -1,0 +1,184 @@
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { heading1Styles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { OrganizationCollectionEntity } from "siren-sdk/src/organizations/OrganizationCollectionEntity.js";
+import {ifDefined} from 'lit-html/directives/if-defined';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/list/list.js';
+import '@brightspace-ui/core/components/list/list-item.js';
+import 'd2l-organizations/components/d2l-organization-image/d2l-organization-image.js';
+
+class AdminList extends EntityMixinLit(LitElement) {
+	static get properties() {
+		return {
+			"title-text": {
+				type: String
+			},
+			_items: {
+				type: Array
+			}
+		};
+	}
+
+	static get styles() {
+		return [
+			heading1Styles,
+			bodyStandardStyles,
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+				.d2l-organization-admin-list-content-container {
+					display: flex;
+					justify-content: center;
+				}
+				.d2l-organization-admin-list-content {
+					box-sizing: border-box;
+					padding: 0 30px;
+					max-width: 1230px;
+					width: 100%;
+				}
+
+				.d2l-organization-admin-list-header-container {
+					border-bottom: solid 1px var(--d2l-color-gypsum);
+					box-sizing: border-box;
+					height: 96px;
+					width: 100%;
+				}
+				.d2l-organization-admin-list-header {
+					align-items: center;
+					display: flex;
+					justify-content: space-between;
+				}
+
+				.d2l-organization-admin-list-body-container {
+					background-color: --var(--d2l-color-regolith);
+				}
+				.d2l-organization-admin-list-body {
+					padding-top: 72px;
+					padding-bottom: 72px;
+				}
+
+				.d2l-organization-admin-list-item-image {
+					border-radius: 6px;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._items = [];
+		this._setEntityType(OrganizationCollectionEntity);
+	}
+
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			console.log(entity);
+			this._onOrganizationCollectionChanged(entity);
+			super._entity = entity;
+		}
+	}
+
+	_onOrganizationCollectionChanged(collection) {
+		this._items = [];
+		this._pageTotal = collection.totalPages();
+		this._pageCurrent = collection.currentPage();
+		this._hasNextPage = collection.hasNextPage();
+		this._hasPrevPage = collection.hasPrevPage();
+		collection.onOrganizationsChange((organization, index) => {
+			this._items[index] = { usage: { editHref: () => 'Wow'}, organization };
+			this.requestUpdate();
+		});
+	}
+
+	render() {
+		const items = this._items.map(
+			item =>
+				html`
+					<d2l-list-item
+						href=${ifDefined(item.usage.editHref())}
+						breakpoints=${[1230, 615, 420, 420]}
+					>
+						<d2l-organization-image
+							class="d2l-organization-admin-list-item-image"
+							href=${item.organization.self()}
+							slot="illustration"
+						></d2l-organization-image>
+						<d2l-list-item-content>
+							<div>${item.organization.name()}</div>
+						</d2l-list-item-content>
+						<div slot="actions">
+							<div>
+								Visible
+							</div>
+							<d2l-button-icon
+								icon="d2l-tier1:delete"
+							></d2l-button-icon>
+						</div>
+					</d2l-list-item>
+				`
+		);
+		return html`
+			<div
+				class="d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container"
+			>
+				<div
+					class="d2l-organization-admin-list-content d2l-organization-admin-list-header"
+				>
+					<h1 class="d2l-heading-1">${this["title-text"]}</h1>
+					<d2l-button primary>Create Learning Path</d2l-button>
+				</div>
+			</div>
+
+			<div
+				class="d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container"
+			>
+				<div
+					class="d2l-organization-admin-list-content d2l-organization-admin-list-body"
+				>
+					<d2l-list>${items}</d2l-list>
+				</div>
+				<div class="discovery-search-results-page-number-container">
+					<d2l-button-icon
+						icon="d2l-tier1:chevron-left"
+						aria-label$="[[localize('pagePrevious')]]"
+						.disabled=${!this._hasPrevPage}
+						on-click="_toPreviousPage"
+						on-keydown="_toPreviousPage"
+					>
+					</d2l-button-icon>
+					<d2l-input-text
+						class="discovery-search-results-page-count"
+						type="number"
+						aria-label$="[[localize('pageSelection', 'pageCurrent', _pageCurrent, 'pageTotal', _pageTotal)]]"
+						name="myInput"
+						value=${this._pageCurrent}
+						min="1"
+						max=${this._pageTotal}
+						size="[[_countDigits(_pageTotal)]]"
+						on-keydown="_toPage"
+						on-blur="_inputPageCounterOnBlur"
+					>
+					</d2l-input-text>
+					<div>
+						/ ${this._pageTotal}
+					</div>
+					<d2l-button-icon
+						icon="d2l-tier1:chevron-right"
+						aria-label$="[[localize('pageNext')]]"
+						.disabled=${!this._hasNextPage}
+						on-click="_toNextPage"
+						on-keydown="_toNextPage"
+					>
+					</d2l-button-icon>
+				</div>
+			</div>
+		`;
+	}
+}
+customElements.define('d2l-organization-admin-list', AdminList);

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -56,11 +56,6 @@ class AdminList extends EntityMixinLit(LitElement) {
 					justify-content: space-between;
 				}
 
-				.d2l-organization-admin-list-body-container {
-					display: flex;
-					flex-direction: column;
-					align-items: center;
-				}
 				.d2l-organization-admin-list-background-gradient {
 					height: 200px;
 					background-image: linear-gradient(
@@ -80,6 +75,17 @@ class AdminList extends EntityMixinLit(LitElement) {
 
 				.d2l-organization-admin-list-item-image {
 					border-radius: 6px;
+				}
+
+				.d2l-organization-admin-list-search-results-page-number-container {
+					margin: 15px;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				}
+				.d2l-organization-admin-list-search-results-page-count {
+					width: auto;
+					max-width: 4rem;
 				}
 			`
 		];
@@ -105,10 +111,22 @@ class AdminList extends EntityMixinLit(LitElement) {
 		this._pageCurrent = collection.currentPage();
 		this._hasNextPage = collection.hasNextPage();
 		this._hasPrevPage = collection.hasPrevPage();
+		this._nextPageHref = collection.getNextPageHref();
+		this._prevPageHref = collection.getPrevPageHref();
 		collection.onOrganizationsChange((organization, index) => {
 			this._items[index] = { usage: { editHref: () => 'Wow'}, organization };
 			this.requestUpdate();
 		});
+	}
+
+	_toPreviousPage() {
+		console.log('to prev page');
+		this.href = this._prevPageHref;
+	}
+
+	_toNextPage() {
+		console.log('to next page');
+		this.href = this._nextPageHref;
 	}
 
 	render() {
@@ -117,7 +135,6 @@ class AdminList extends EntityMixinLit(LitElement) {
 				html`
 					<d2l-list-item
 						href=${ifDefined(item.usage.editHref())}
-						breakpoints=${[1230, 615, 420, 420]}
 					>
 						<d2l-organization-image
 							class="d2l-organization-admin-list-item-image"
@@ -127,71 +144,53 @@ class AdminList extends EntityMixinLit(LitElement) {
 						<d2l-list-item-content>
 							<div>${item.organization.name()}</div>
 						</d2l-list-item-content>
-						<div slot="actions">
-							<div>
-								Visible
-							</div>
-							<d2l-button-icon
-								icon="d2l-tier1:delete"
-							></d2l-button-icon>
-						</div>
 					</d2l-list-item>
 				`
 		);
 		return html`
-			<div
-				class="d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container"
-			>
-				<div
-					class="d2l-organization-admin-list-content d2l-organization-admin-list-header"
-				>
+			<div class="d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container">
+				<div class="d2l-organization-admin-list-content d2l-organization-admin-list-header">
 					<h1 class="d2l-heading-1">${this["title-text"]}</h1>
 					<d2l-button primary>Create Learning Path</d2l-button>
 				</div>
 			</div>
 
-			<div
-				class="d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container"
-			>
+			<div class="d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container">
 				<div class="d2l-organization-admin-list-background-gradient"></div>
-				<div
-					class="d2l-organization-admin-list-content d2l-organization-admin-list-body"
-				>
+				<div class="d2l-organization-admin-list-content d2l-organization-admin-list-body">
 					<d2l-list>${items}</d2l-list>
-				</div>
-				<div class="discovery-search-results-page-number-container">
-					<d2l-button-icon
-						icon="d2l-tier1:chevron-left"
-						aria-label$="[[localize('pagePrevious')]]"
-						.disabled=${!this._hasPrevPage}
-						on-click="_toPreviousPage"
-						on-keydown="_toPreviousPage"
-					>
-					</d2l-button-icon>
-					<d2l-input-text
-						class="discovery-search-results-page-count"
-						type="number"
-						aria-label$="[[localize('pageSelection', 'pageCurrent', _pageCurrent, 'pageTotal', _pageTotal)]]"
-						name="myInput"
-						value=${this._pageCurrent}
-						min="1"
-						max=${this._pageTotal}
-						size="[[_countDigits(_pageTotal)]]"
-						on-keydown="_toPage"
-						on-blur="_inputPageCounterOnBlur"
-					>
-					</d2l-input-text>
-					<div>
-						/ ${this._pageTotal}
+					<div class="d2l-organization-admin-list-search-results-page-number-container">
+						<d2l-button-icon
+							icon="d2l-tier1:chevron-left"
+							aria-label$="[[localize('pagePrevious')]]"
+							.disabled=${!this._hasPrevPage}
+							@click=${this._toPreviousPage}
+							on-keydown=${this._toPreviousPage}
+						>
+						</d2l-button-icon>
+						<d2l-input-text
+							class="d2l-organization-admin-list-search-results-page-count"
+							type="number"
+							aria-label$="[[localize('pageSelection', 'pageCurrent', _pageCurrent, 'pageTotal', _pageTotal)]]"
+							name="myInput"
+							value=${this._pageCurrent}
+							min="1"
+							max=${this._pageTotal}
+							size="[[_countDigits(_pageTotal)]]"
+							on-keydown="_toPage"
+							on-blur="_inputPageCounterOnBlur"
+						>
+						</d2l-input-text>
+						<div>&nbsp/&nbsp${this._pageTotal}</div>
+						<d2l-button-icon
+							icon="d2l-tier1:chevron-right"
+							aria-label$="[[localize('pageNext')]]"
+							.disabled=${!this._hasNextPage}
+							@click=${this._toNextPage}
+							on-keydown=${this._toNextPage}
+						>
+						</d2l-button-icon>
 					</div>
-					<d2l-button-icon
-						icon="d2l-tier1:chevron-right"
-						aria-label$="[[localize('pageNext')]]"
-						.disabled=${!this._hasNextPage}
-						on-click="_toNextPage"
-						on-keydown="_toNextPage"
-					>
-					</d2l-button-icon>
 				</div>
 			</div>
 		`;

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -39,7 +39,8 @@ class AdminList extends EntityMixinLit(LitElement) {
 				}
 				.d2l-organization-admin-list-content {
 					box-sizing: border-box;
-					padding: 0 2.439%;
+					padding-left: 2.439%;
+					padding-right: 2.439%;
 					max-width: 1230px;
 					width: 100%;
 				}
@@ -104,13 +105,15 @@ class AdminList extends EntityMixinLit(LitElement) {
 
 				@media (max-width: 615px) {
 					.d2l-organization-admin-list-content {
-						padding: 0 15px;
+						padding-left: 15px;
+						padding-right: 15px;
 					}
 				}
 
 				@media (min-width: 1230px) {
 					.d2l-organization-admin-list-content {
-						padding: 0 30px;
+						padding-left: 30px;
+						padding-right: 30px;
 					}
 				}
 			`
@@ -160,6 +163,7 @@ class AdminList extends EntityMixinLit(LitElement) {
 			item =>
 				html`
 					<d2l-list-item
+						.breakpoints=${[1170, 391, 0, 0]}
 						href=${ifDefined(item.usage.editHref())}
 					>
 						<d2l-organization-image

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -1,20 +1,20 @@
-import "../d2l-organization-image/d2l-organization-image.js";
-import "./d2l-organization-admin-list-pager.js";
-import "./d2l-organization-admin-list-search-header.js";
-import "@brightspace-ui/core/components/button/button.js";
-import "@brightspace-ui/core/components/colors/colors.js";
-import "@brightspace-ui/core/components/list/list-item.js";
-import "@brightspace-ui/core/components/list/list.js";
+import '../d2l-organization-image/d2l-organization-image.js';
+import './d2l-organization-admin-list-pager.js';
+import './d2l-organization-admin-list-search-header.js';
+import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/list/list-item.js';
+import '@brightspace-ui/core/components/list/list.js';
 import {
 	heading1Styles,
 	bodyStandardStyles
-} from "@brightspace-ui/core/components/typography/styles.js";
-import { EntityMixinLit } from "siren-sdk/src/mixin/entity-mixin-lit.js";
-import { getLocalizeResources } from "./localization.js";
-import { ifDefined } from "lit-html/directives/if-defined";
-import { css, html, LitElement } from "lit-element/lit-element.js";
-import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
-import { OrganizationCollectionEntity } from "siren-sdk/src/organizations/OrganizationCollectionEntity.js";
+} from '@brightspace-ui/core/components/typography/styles.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { getLocalizeResources } from './localization.js';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { OrganizationCollectionEntity } from 'siren-sdk/src/organizations/OrganizationCollectionEntity.js';
 
 class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	static get properties() {
@@ -168,7 +168,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 					};
 					loadedCount++;
 					if (loadedCount >= totalCount) {
-						this.requestUpdate("_items", []);
+						this.requestUpdate('_items', []);
 					}
 				});
 			}
@@ -196,7 +196,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	_createOrgUnit() {
 		const name = this.localize(this.createActionDefaultNameTerm);
 		this._collection
-			.createOrgUnit(name, "LP", this.createActionType)
+			.createOrgUnit(name, 'LP', this.createActionType)
 			.then(organization => {
 				organization.onActivityUsageChange(activityUsage => {
 					window.location.href = activityUsage.editHref();
@@ -213,9 +213,9 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						href=${ifDefined(item.usage.editHref())}
 					>
 						<d2l-organization-image
-							class="d2l-organization-admin-list-item-image"
+							class='d2l-organization-admin-list-item-image'
 							href=${item.organization.self()}
-							slot="illustration"
+							slot='illustration'
 						></d2l-organization-image>
 						<d2l-list-item-content>
 							<div>${item.organization.name()}</div>
@@ -224,16 +224,16 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				`
 		);
 		return html`
-			<div class="d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container">
-				<div class="d2l-organization-admin-list-content d2l-organization-admin-list-header">
-					<h1 class="d2l-heading-1 d2l-organization-admin-list-title">
+			<div class='d2l-organization-admin-list-content-container d2l-organization-admin-list-header-container'>
+				<div class='d2l-organization-admin-list-content d2l-organization-admin-list-header'>
+					<h1 class='d2l-heading-1 d2l-organization-admin-list-title'>
 						${this.titleText}
 					</h1>
 					${ this._collection && this._collection.canCreateOrgUnit() ? html`
 						<d2l-button
-							class="d2l-organization-admin-list-create-button"
+							class='d2l-organization-admin-list-create-button'
 							primary
-							@click="${this._createOrgUnit}"
+							@click='${this._createOrgUnit}'
 						>
 							${this.localize(this.createActionTitleTerm)}
 						</d2l-button>
@@ -241,9 +241,9 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				</div>
 			</div>
 
-			<div class="d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container">
-				<div class="d2l-organization-admin-list-background-gradient"></div>
-				<div class="d2l-organization-admin-list-content d2l-organization-admin-list-body">
+			<div class='d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container'>
+				<div class='d2l-organization-admin-list-background-gradient'></div>
+				<div class='d2l-organization-admin-list-content d2l-organization-admin-list-body'>
 					<d2l-organization-admin-list-search-header .onSearchTextChanged=${this._handleSearch.bind(this)}>
 					</d2l-organization-admin-list-search-header>
 					<d2l-list>${items}</d2l-list>
@@ -254,4 +254,4 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		`;
 	}
 }
-customElements.define("d2l-organization-admin-list", AdminList);
+customElements.define('d2l-organization-admin-list', AdminList);

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -193,6 +193,17 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		}
 	}
 
+	_createOrgUnit() {
+		const name = this.localize(this.createActionDefaultNameTerm);
+		this._collection
+			.createOrgUnit(name, "LP", this.createActionType)
+			.then(organization => {
+				organization.onActivityUsageChange(activityUsage => {
+					window.location.href = activityUsage.editHref();
+				});
+			});
+	}
+
 	render() {
 		const items = this._items.map(
 			item =>

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -35,6 +35,7 @@ class AdminList extends EntityMixinLit(LitElement) {
 				.d2l-organization-admin-list-content-container {
 					display: flex;
 					justify-content: center;
+					position: relative;
 				}
 				.d2l-organization-admin-list-content {
 					box-sizing: border-box;
@@ -56,7 +57,21 @@ class AdminList extends EntityMixinLit(LitElement) {
 				}
 
 				.d2l-organization-admin-list-body-container {
-					background-color: --var(--d2l-color-regolith);
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+				}
+				.d2l-organization-admin-list-background-gradient {
+					height: 200px;
+					background-image: linear-gradient(
+						to top,
+						white 50%,
+						var(--d2l-color-regolith)
+					);
+					width: 100%;
+					position: absolute;
+					left: 0;
+					top: 0;
 				}
 				.d2l-organization-admin-list-body {
 					padding-top: 72px;
@@ -138,6 +153,7 @@ class AdminList extends EntityMixinLit(LitElement) {
 			<div
 				class="d2l-organization-admin-list-content-container d2l-organization-admin-list-body-container"
 			>
+				<div class="d2l-organization-admin-list-background-gradient"></div>
 				<div
 					class="d2l-organization-admin-list-content d2l-organization-admin-list-body"
 				>

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -1,20 +1,20 @@
-import { css, html, LitElement } from "lit-element/lit-element.js";
+import "../d2l-organization-image/d2l-organization-image.js";
+import "./d2l-organization-admin-list-pager.js";
+import "./d2l-organization-admin-list-search-header.js";
+import "@brightspace-ui/core/components/button/button.js";
+import "@brightspace-ui/core/components/colors/colors.js";
+import "@brightspace-ui/core/components/list/list-item.js";
+import "@brightspace-ui/core/components/list/list.js";
 import {
 	heading1Styles,
 	bodyStandardStyles
 } from "@brightspace-ui/core/components/typography/styles.js";
 import { EntityMixinLit } from "siren-sdk/src/mixin/entity-mixin-lit.js";
+import { getLocalizeResources } from "./localization.js";
+import { ifDefined } from "lit-html/directives/if-defined";
+import { css, html, LitElement } from "lit-element/lit-element.js";
 import { LocalizeMixin } from "@brightspace-ui/core/mixins/localize-mixin.js";
 import { OrganizationCollectionEntity } from "siren-sdk/src/organizations/OrganizationCollectionEntity.js";
-import { ifDefined } from "lit-html/directives/if-defined";
-import "@brightspace-ui/core/components/colors/colors.js";
-import "@brightspace-ui/core/components/button/button.js";
-import "@brightspace-ui/core/components/list/list.js";
-import "@brightspace-ui/core/components/list/list-item.js";
-import "d2l-organizations/components/d2l-organization-image/d2l-organization-image.js";
-import "./d2l-organization-admin-list-pager.js";
-import "./d2l-organization-admin-list-search-header.js";
-import { getLocalizeResources } from "./localization.js";
 
 class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	static get properties() {
@@ -64,9 +64,9 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				}
 				.d2l-organization-admin-list-content {
 					box-sizing: border-box;
+					max-width: 1230px;
 					padding-left: 2.439%;
 					padding-right: 2.439%;
-					max-width: 1230px;
 					width: 100%;
 				}
 
@@ -85,21 +85,21 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				}
 
 				.d2l-organization-admin-list-background-gradient {
-					height: 200px;
 					background-image: linear-gradient(
 						to top,
 						white 50%,
 						var(--d2l-color-regolith)
 					);
-					width: 100%;
-					position: absolute;
+					height: 200px;
 					left: 0;
+					position: absolute;
 					top: 0;
+					width: 100%;
 					z-index: -1;
 				}
 				.d2l-organization-admin-list-body {
-					padding-top: 6px;
 					padding-bottom: 72px;
+					padding-top: 6px;
 				}
 
 				.d2l-organization-admin-list-item-image {
@@ -108,13 +108,13 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 				@media (max-width: 420px) {
 					.d2l-organization-admin-list-header {
+						align-items: flex-start;
 						flex-direction: column;
 						justify-content: flex-start;
-						align-items: flex-start;
 					}
 					.d2l-organization-admin-list-create-button {
-						width: 100%;
 						margin-bottom: 24px;
+						width: 100%;
 					}
 				}
 

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -1,0 +1,11 @@
+/* eslint quotes: 0 */
+
+export default {
+	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
+	"createActionDefaultNameTerm": "Untitled Learning Path", // Default name given to a newly created Learning Path
+	"search": "Search", // Label for the search input to search the list of org units
+	"searchPlaceholder": "Search...", // Placeholder text for the search input to search the list of org units
+	"pagePrevious": "To previous page", // Label for the back to previous page button
+	"pageNext": "To next page", // Label for the next page button
+	"pageSelection": "On page {pageCurrent} of {pageTotal}. Enter a page number to go to that page", // Label for the page number input that lists the current page and lets the user jump to specific pages
+};

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -2,7 +2,7 @@
 
 export default {
 	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
-	"createActionDefaultNameTerm": "Untitled Learning Path", // Default name given to a newly created Learning Path
+	"defaultLearningPathName": "Untitled Learning Path", // Default name given to a newly created Learning Path
 	"search": "Search", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Search...", // Placeholder text for the search input to search the list of org units
 	"pagePrevious": "To previous page", // Label for the back to previous page button

--- a/components/d2l-organization-admin-list/localization.js
+++ b/components/d2l-organization-admin-list/localization.js
@@ -1,17 +1,17 @@
-import { resolveUrl } from "@polymer/polymer/lib/utils/resolve-url.js";
+import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 export async function getLocalizeResources(langs, importMetaUrl) {
 	const imports = [];
 	let supportedLanguage;
 	for (const language of langs.reverse()) {
 		switch (language) {
-			case "en":
-				supportedLanguage = "en";
-				imports.push(import(resolveUrl("./lang/en.js", importMetaUrl)));
+			case 'en':
+				supportedLanguage = 'en';
+				imports.push(import(resolveUrl('./lang/en.js', importMetaUrl)));
 				break;
-			case "fr":
-				supportedLanguage = "fr";
-				imports.push(import(resolveUrl("./lang/fr.js", importMetaUrl)));
+			case 'fr':
+				supportedLanguage = 'fr';
+				imports.push(import(resolveUrl('./lang/fr.js', importMetaUrl)));
 				break;
 		}
 	}

--- a/components/d2l-organization-admin-list/localization.js
+++ b/components/d2l-organization-admin-list/localization.js
@@ -1,0 +1,31 @@
+import { resolveUrl } from "@polymer/polymer/lib/utils/resolve-url.js";
+
+export async function getLocalizeResources(langs, importMetaUrl) {
+	const imports = [];
+	let supportedLanguage;
+	for (const language of langs.reverse()) {
+		switch (language) {
+			case "en":
+				supportedLanguage = "en";
+				imports.push(import(resolveUrl("./lang/en.js", importMetaUrl)));
+				break;
+			case "fr":
+				supportedLanguage = "fr";
+				imports.push(import(resolveUrl("./lang/fr.js", importMetaUrl)));
+				break;
+		}
+	}
+
+	const translationFiles = await Promise.all(imports);
+	const langterms = {};
+	for (const translationFile of translationFiles) {
+		for (const langterm in translationFile.default) {
+			langterms[langterm] = translationFile.default[langterm];
+		}
+	}
+
+	return {
+		language: supportedLanguage,
+		resources: langterms
+	};
+}

--- a/demo/d2l-organization-admin-list/d2l-organization-admin-list.html
+++ b/demo/d2l-organization-admin-list/d2l-organization-admin-list.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-organization-admin-list demo</title>
+		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
+
+		<script type="module">
+			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+			import '@polymer/iron-demo-helpers/demo-snippet';
+			import 'd2l-typography/d2l-typography.js';
+			import '../../components/d2l-organization-admin-list/d2l-organization-admin-list.js';
+
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = `
+				<custom-style>
+					<style is="custom-style" include="demo-pages-shared-styles"></style>
+				</custom-style>
+				<custom-style include="d2l-typography">
+					<style is="custom-style" include="d2l-typography">
+						html {
+							font-size: 20px;
+						}
+						h3 {
+							text-align: center;
+						}
+						.demo {
+							align-items: center;
+							background-color: white;
+							padding: 50px;
+						}
+					</style>
+				</custom-style>
+			`;
+			document.body.appendChild($_documentContainer.content);
+			window.D2L.Siren.WhitelistBehavior._inTestMode = true;
+		</script>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container">
+			<h3>d2l-organization-admin-list demo</h3>
+			<demo-snippet>
+				<template>
+					<div class="demo">
+						<d2l-organization-admin-list
+							href="../data/organization-collection/organization-collection-1.json"
+							token="whatever"
+							titleText="Learning Paths"
+							createActionTitleTerm="createLearningPath"
+						></d2l-organization-availability-set>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/data/organization-collection/organization-activity-usage.json
+++ b/demo/data/organization-collection/organization-activity-usage.json
@@ -1,0 +1,64 @@
+{
+    "class": [
+        "activity-usage",
+        "learning-path",
+        "draft-published-entity",
+        "published"
+    ],
+    "links": [
+        {
+            "rel": [
+                "https://activities.api.brightspace.com/rels/activity-usage",
+                "self"
+            ],
+            "href": "https://activities.api.proddev.d2l/activities/6606_706000_123059/usages/123059"
+        },
+        {
+            "rel": [
+                "https://activities.api.brightspace.com/rels/user-activity-usage",
+                "https://activities.api.brightspace.com/rels/my-activity-usage"
+            ],
+            "href": "https://activities.api.proddev.d2l/activities/6606_706000_123059/usages/123059/users/169"
+        },
+        {
+            "rel": [
+                "https://api.brightspace.com/rels/dismiss"
+            ],
+            "href": "https://activities.api.proddev.d2l/activities/6606_706000_123059/usages/123059/dismiss-info"
+        },
+        {
+            "rel": [
+                "https://activities.api.brightspace.com/rels/activity-collection"
+            ],
+            "href": "https://activities.api.proddev.d2l/activities/6606_706000_123059/usages/123059/collection"
+        },
+        {
+            "rel": [
+                "https://api.brightspace.com/rels/organization",
+                "https://api.brightspace.com/rels/specialization"
+            ],
+            "href": "https://organizations.api.proddev.d2l/123059"
+        },
+        {
+            "rel": [
+                "edit"
+            ],
+            "type": "text/html",
+            "href": "http://localhost:8080/d2l/le/learningpaths/admin/123059/edit"
+        }
+    ],
+    "actions": [
+        {
+            "href": "https://organizations.api.proddev.d2l/activity-usage/123059",
+            "name": "update-draft",
+            "method": "PATCH",
+            "fields": [
+                {
+                    "type": "checkbox",
+                    "name": "draft",
+                    "value": false
+                }
+            ]
+        }
+    ]
+}

--- a/demo/data/organization-collection/organization-collection-1.json
+++ b/demo/data/organization-collection/organization-collection-1.json
@@ -1,0 +1,5734 @@
+{
+    "class": [
+        "paged",
+        "organization",
+        "collection"
+    ],
+    "properties": {
+        "pagingInfo": {
+            "total": 22,
+            "page": 1,
+            "pageSize": 20
+        }
+    },
+    "entities": [
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#008380",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123059/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123059/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123059/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123059"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123059/users/169?start=2019-12-11T22%3a07%3a17.698Z&end=2019-12-18T22%3a07%3a17.698Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123059?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123059"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123059/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123059/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123059?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123059"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123059/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#00BDDD",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123060/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123060/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123060/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123060"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123060/users/169?start=2019-12-11T22%3a07%3a17.727Z&end=2019-12-18T22%3a07%3a17.727Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123060"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123060?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123060"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123060/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123060"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123060"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123060/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123060?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123060"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123060"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123060/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#4F8F1E",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123061/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123061/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123061/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123061"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123061/users/169?start=2019-12-11T22%3a07%3a17.782Z&end=2019-12-18T22%3a07%3a17.782Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123061"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123061?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123061"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123061/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123061"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123061"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123061/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123061?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123061"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123061"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123061/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#851519",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123062/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123062/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123062/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123062"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123062/users/169?start=2019-12-11T22%3a07%3a17.823Z&end=2019-12-18T22%3a07%3a17.823Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123062"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123062?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123062"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123062/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123062"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123062"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123062/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123062?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123062"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123062"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123062/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#006FBF",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123063/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123063/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123063/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123063"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123063/users/169?start=2019-12-11T22%3a07%3a17.873Z&end=2019-12-18T22%3a07%3a17.873Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123063"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123063?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123063"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123063/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123063"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123063"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123063/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123063?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123063"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123063"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123063/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#008EA6",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123064/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123064/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123064/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123064"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123064/users/169?start=2019-12-11T22%3a07%3a17.908Z&end=2019-12-18T22%3a07%3a17.908Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123064"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123064?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123064"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123064/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123064"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123064"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123064/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123064?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123064"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123064"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123064/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#A8BA26",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123065/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123065/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123065/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123065"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123065/users/169?start=2019-12-11T22%3a07%3a17.949Z&end=2019-12-18T22%3a07%3a17.949Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123065"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123065?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123065"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123065/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123065"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123065"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123065/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123065?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123065"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123065"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123065/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#064A7B",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123066/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123066/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123066/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123066"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123066/users/169?start=2019-12-11T22%3a07%3a17.985Z&end=2019-12-18T22%3a07%3a17.985Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123066"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123066?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123066"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123066/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123066"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123066"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123066/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123066?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123066"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123066"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123066/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#1C5295",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123067/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123067/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123067/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123067"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123067/users/169?start=2019-12-11T22%3a07%3a18.028Z&end=2019-12-18T22%3a07%3a18.028Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123067"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123067?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123067"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123067/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123067"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123067"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123067/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123067?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123067"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123067"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123067/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#4F8F1E",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123068/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123068/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123068/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123068"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123068/users/169?start=2019-12-11T22%3a07%3a18.058Z&end=2019-12-18T22%3a07%3a18.058Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123068"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123068?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123068"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123068/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123068"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123068"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123068/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123068?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123068"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123068"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123068/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#CC9547",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123069/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123069/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123069/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123069"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123069/users/169?start=2019-12-11T22%3a07%3a18.093Z&end=2019-12-18T22%3a07%3a18.093Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123069"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123069?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123069"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123069/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123069"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123069"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123069/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123069?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123069"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123069"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123069/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#A8BA26",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123070/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123070/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123070/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123070"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123070/users/169?start=2019-12-11T22%3a07%3a18.126Z&end=2019-12-18T22%3a07%3a18.126Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123070"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123070?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123070"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123070/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123070"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123070"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123070/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123070?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123070"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123070"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123070/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#4C3F99",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123071/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123071/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123071/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123071"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123071/users/169?start=2019-12-11T22%3a07%3a18.156Z&end=2019-12-18T22%3a07%3a18.156Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123071"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123071?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123071"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123071/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123071"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123071"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123071/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123071?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123071"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123071"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123071/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#D0C94D",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123072/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123072/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123072/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123072"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123072/users/169?start=2019-12-11T22%3a07%3a18.182Z&end=2019-12-18T22%3a07%3a18.182Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123072"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123072?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123072"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123072/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123072"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123072"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123072/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123072?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123072"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123072"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123072/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#D0C94D",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123073/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123073/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123073/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123073"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123073/users/169?start=2019-12-11T22%3a07%3a18.216Z&end=2019-12-18T22%3a07%3a18.216Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123073"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123073?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123073"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123073/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123073"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123073"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123073/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123073?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123073"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123073"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123073/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#4F8F1E",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123074/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123074/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123074/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123074"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123074/users/169?start=2019-12-11T22%3a07%3a18.241Z&end=2019-12-18T22%3a07%3a18.241Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123074"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123074?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123074"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123074/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123074"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123074"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123074/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123074?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123074"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123074"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123074/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#E57231",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123075/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123075/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123075/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123075"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123075/users/169?start=2019-12-11T22%3a07%3a18.263Z&end=2019-12-18T22%3a07%3a18.263Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123075"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123075?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123075"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123075/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123075"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123075"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123075/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123075?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123075"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123075"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123075/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#4F8F1E",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123076/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123076/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123076/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123076"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123076/users/169?start=2019-12-11T22%3a07%3a18.284Z&end=2019-12-18T22%3a07%3a18.284Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123076"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123076?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123076"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123076/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123076"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123076"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123076/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123076?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123076"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123076"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123076/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#FF389B",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123077/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123077/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123077/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123077"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123077/users/169?start=2019-12-11T22%3a07%3a18.312Z&end=2019-12-18T22%3a07%3a18.312Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123077"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123077?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123077"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123077/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123077"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123077"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123077/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123077?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123077"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123077"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123077/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#00A8DD",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123078/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123078/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123078/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123078"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123078/users/169?start=2019-12-11T22%3a07%3a18.342Z&end=2019-12-18T22%3a07%3a18.342Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123078?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123078"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123078/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123078/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123078?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123078"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123078/3"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "../data/organization-collection/organization-collection-1.json"
+        },
+        {
+            "rel": [
+                "next"
+            ],
+            "href": "../data/organization-collection/organization-collection-2.json"
+        }
+    ],
+    "actions": [
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "search-course-collection",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-department-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7,203"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-semester-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7,5"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-active-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7"
+                },
+                {
+                    "type": "checkbox",
+                    "name": "active",
+                    "value": true
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "create-org-unit",
+            "method": "POST",
+            "fields": [
+                {
+                    "type": "number",
+                    "name": "orgUnitTypeId"
+                },
+                {
+                    "type": "text",
+                    "name": "name"
+                },
+                {
+                    "type": "text",
+                    "name": "code"
+                },
+                {
+                    "type": "number",
+                    "name": "parentId",
+                    "value": 6606
+                },
+                {
+                    "type": "checkbox",
+                    "name": "draft",
+                    "value": true
+                }
+            ]
+        }
+    ]
+}

--- a/demo/data/organization-collection/organization-collection-2.json
+++ b/demo/data/organization-collection/organization-collection-2.json
@@ -1,0 +1,748 @@
+{
+    "class": [
+        "paged",
+        "organization",
+        "collection"
+    ],
+    "properties": {
+        "pagingInfo": {
+            "total": 22,
+            "page": 2,
+            "pageSize": 20
+        }
+    },
+    "entities": [
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#008380",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123059/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123059/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123059/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123059"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123059/users/169?start=2019-12-11T22%3a07%3a17.698Z&end=2019-12-18T22%3a07%3a17.698Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123059?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123059"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123059/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123059/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123059?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123059"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123059"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123059/3"
+                }
+            ]
+        },
+        {
+            "class": [
+                "named-entity",
+                "describable-entity",
+                "draft-published-entity",
+                "published",
+                "active",
+                "learning-path"
+            ],
+            "rel": [
+                "https://api.brightspace.com/rels/organization"
+            ],
+            "properties": {
+                "name": "Learning Path 1",
+                "code": null,
+                "startDate": null,
+                "endDate": null,
+                "isActive": true,
+                "description": ""
+            },
+            "entities": [
+                {
+                    "class": [
+                        "richtext",
+                        "description"
+                    ],
+                    "rel": [
+                        "item"
+                    ],
+                    "properties": {
+                        "text": "",
+                        "html": null
+                    }
+                },
+                {
+                    "class": [
+                        "color"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/color"
+                    ],
+                    "properties": {
+                        "hexString": "#00A8DD",
+                        "description": ""
+                    }
+                },
+                {
+                    "class": [
+                        "course-image"
+                    ],
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-image"
+                    ],
+                    "href": "../data/image.json"
+                },
+                {
+                    "class": [
+                        "relative-uri"
+                    ],
+                    "rel": [
+                        "item",
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "properties": {
+                        "path": "/d2l/le/learningpaths/123078/View"
+                    }
+                }
+            ],
+            "actions": [
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-name",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "name",
+                            "value": "Learning Path 1"
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-description",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "class": [
+                                "required"
+                            ],
+                            "type": "text",
+                            "name": "description",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "update-draft",
+                    "method": "PATCH",
+                    "fields": [
+                        {
+                            "type": "checkbox",
+                            "name": "draft",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/lp/1.9/courses/123078/image",
+                    "name": "set-catalog-image",
+                    "method": "POST",
+                    "fields": [
+                        {
+                            "type": "text",
+                            "name": "imagePath",
+                            "value": ""
+                        }
+                    ]
+                },
+                {
+                    "href": "../data/learningPath/organization-learning-path.json",
+                    "name": "add-homepage-banner",
+                    "method": "PUT",
+                    "fields": [
+                        {
+                            "type": "hidden",
+                            "name": "showCourseBanner",
+                            "value": true
+                        }
+                    ]
+                }
+            ],
+            "links": [
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-awards"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/awards/organizations/123078/users/169"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123078"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/my-organization-activities"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/activities/activityusages/123078/users/169?start=2019-12-11T22%3a07%3a18.342Z&end=2019-12-18T22%3a07%3a18.342Z"
+                },
+                {
+                    "rel": [
+                        "https://checklists.api.brightspace.com/rels/checklists"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/checklists/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://activities.api.brightspace.com/rels/activity-usage"
+                    ],
+                    "href": "../data/organization-collection/organization-activity-usage.json"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/sequence"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/sequences/123078?deepEmbedEntities=1&filterOnDatesAndDepth=0"
+                },
+                {
+                    "rel": [
+                        "https://files.api.brightspace.com/rels/files"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/files/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/discussions"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/discussions/123078"
+                },
+                {
+                    "rel": [
+                        "https://assignments.api.brightspace.com/rels/assignments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/assignments/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/my-organization-grades"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/grades/organizations/123078/users/169"
+                },
+                {
+                    "rel": [
+                        "https://announcements.api.brightspace.com/rels/organization-announcements"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/announcements/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://surveys.api.brightspace.com/rels/surveys"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/surveys/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/organization-notifications"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/my-notifications/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/enrollments"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/course-offering-info-page"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/lp/manageCourses/course_offering_info_viewedit.d2l?ou=123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/organization-homepage"
+                    ],
+                    "type": "text/html",
+                    "href": "http://organizations.api.proddev.d2l/d2l/le/learningpaths/123078/View"
+                },
+                {
+                    "rel": [
+                        "self"
+                    ],
+                    "href": "../data/learningPath/organization-learning-path.json"
+                },
+                {
+                    "rel": [
+                        "https://enrollments.api.brightspace.com/rels/primary-facilitators"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/enrollments/organizations/123078?filter=eyJkN2E5ZTM5Ny1lMDFiLTRjZjctODIxZS1mYWU3M2Q2MjgzMDUiOlsicHJpbWFyeUluc3RydWN0b3IiXX0"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/notification-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/alerts/notification-alerts"
+                },
+                {
+                    "rel": [
+                        "https://notifications.api.brightspace.com/rels/my-alerts"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/notifications/alerts/123078"
+                },
+                {
+                    "rel": [
+                        "https://api.brightspace.com/rels/rubrics"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/rubrics/organizations/123078"
+                },
+                {
+                    "class": [
+                        "active",
+                        "theme"
+                    ],
+                    "rel": [
+                        "https://themes.api.brightspace.com/rels/theme"
+                    ],
+                    "href": "http://organizations.api.proddev.d2l/d2l/api/hm/themes/123078/3"
+                }
+            ]
+        }
+    ],
+    "links": [
+        {
+            "rel": [
+                "self"
+            ],
+            "href": "../data/organization-collection/organization-collection-2.json"
+        },
+        {
+            "rel": [
+                "prev"
+            ],
+            "href": "../data/organization-collection/organization-collection-1.json"
+        }
+    ],
+    "actions": [
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "search-course-collection",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-department-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7,203"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-semester-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7,5"
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "add-active-filter",
+            "method": "GET",
+            "fields": [
+                {
+                    "type": "search",
+                    "name": "search",
+                    "value": ""
+                },
+                {
+                    "type": "number",
+                    "name": "page",
+                    "value": "1"
+                },
+                {
+                    "type": "number",
+                    "name": "pageSize",
+                    "value": "20"
+                },
+                {
+                    "type": "number",
+                    "name": "embedDepth",
+                    "value": "1"
+                },
+                {
+                    "type": "hidden",
+                    "name": "organizationTypeIds",
+                    "value": "7"
+                },
+                {
+                    "type": "checkbox",
+                    "name": "active",
+                    "value": true
+                }
+            ]
+        },
+        {
+            "href": "http://organizations.api.proddev.d2l/d2l/api/hm/organizations",
+            "name": "create-org-unit",
+            "method": "POST",
+            "fields": [
+                {
+                    "type": "number",
+                    "name": "orgUnitTypeId"
+                },
+                {
+                    "type": "text",
+                    "name": "name"
+                },
+                {
+                    "type": "text",
+                    "name": "code"
+                },
+                {
+                    "type": "number",
+                    "name": "parentId",
+                    "value": 6606
+                },
+                {
+                    "type": "checkbox",
+                    "name": "draft",
+                    "value": true
+                }
+            ]
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@polymer/iron-test-helpers": "^3.0.0",
     "@ungap/url-search-params": "^0.1.2",
     "@webcomponents/webcomponentsjs": "^2.2.6",
+    "axe-core": "^3.4.0",
     "babel-eslint": "^10.0.1",
     "chai-dom": "^1.8.0",
     "del": "^3.0.0",
@@ -69,9 +70,9 @@
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1",
     "lie": "^3.3.0",
+    "lit-element": "^2.2.1",
     "siren-parser": "^8.0.0",
     "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1",
-    "whatwg-fetch": "^3.0.0",
-    "lit-element": "^2.2.1"
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/test/d2l-organization-admin-list/d2l-organization-admin-list.html
+++ b/test/d2l-organization-admin-list/d2l-organization-admin-list.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../../wct-browser-legacy/browser.js"></script>
+
+		<script type="module" src="../../../siren-parser/global.js"></script>
+		<script type="module" src="../../components/d2l-organization-admin-list/d2l-organization-admin-list.js"></script>
+	</head>
+	<body>
+		<test-fixture id="admin-list">
+			<template>
+				<d2l-organization-admin-list titleText="Learning Paths"></d2l-organization-admin-list>
+			</template>
+		</test-fixture>
+
+		<script type="module" src="./d2l-organization-admin-list.js"></script>
+	</body>
+</html>

--- a/test/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/test/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -1,0 +1,28 @@
+import { runAxe } from '@brightspace-ui/core/tools/a11y-test-helper.js';
+
+describe('d2l-organization-admin-list', () => {
+	let element;
+	let collectionEntity;
+
+	beforeEach(async() => {
+		element = fixture('admin-list');
+		await element.updateComplete;
+
+		collectionEntity = {};
+	});
+
+	it('should pass all axe tests', async() => {
+		await runAxe(element);
+	});
+
+	it('should reset items on collection changed', () => {
+		collectionEntity.onOrganizationsChange = () => {};
+		collectionEntity.totalPages = () => 1;
+		collectionEntity.currentPage = () => 1;
+		element._items = ['non', 'empty', 'items', 'array'];
+
+		element._onOrganizationCollectionChanged(collectionEntity);
+
+		expect(element._items).to.be.empty;
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@
 	<body>
 		<script>
 			WCT.loadSuites([
+				'./d2l-organization-admin-list/d2l-organization-admin-list.html',
 				'./d2l-organization-availability-set/d2l-current-organization-availability.html',
 				'./d2l-organization-availability-set/d2l-organization-availability-set.html',
 				'./d2l-organization-availability-set/d2l-organization-availability.html',

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -23,7 +23,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.13",
-					"version": "11.1"
+					"version": ""
 				}
 			]
 		}


### PR DESCRIPTION
# Changes
This pull request adds a component to list all org units through the organizations HM domain with support for paging, searching, and creating new org units.