### PR TITLE
Fixed infinite loading defect in admin pager

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list-pager.js
@@ -75,7 +75,14 @@ class AdminListPager extends LocalizeMixin(LitElement) {
 	}
 
 	_toPage(e) {
-		this.onPageChanged(e.target.value);
+		// handle invalid input
+		const value = Number(e.target.value);
+		if (!Number.isInteger(value) || value < 1 || value > this.totalPages) {
+			// reset to original
+			e.target.value = this.currentPage;
+			return;
+		}
+		this.onPageChanged(value);
 	}
 
 	_countDigits(number) {


### PR DESCRIPTION
[DE37563](https://rally1.rallydev.com/#/detail/defect/363231455104?fdp=true)

A user was able to enter any number into the "goto page" input area, resulting in requests for negative numbers, floats, numbers greater than the total page number, and numbers with "e" in them. A short validation check has been added to the pager to prevent all of these cases. The pager will reset its input to the current page on bad input, which is currently how Discussions handles this case.