### PR TITLE
Changed lang to include the deleted org's name and specified text

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -50,7 +50,8 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			},
 			_collection: {
 				type: Object
-			}
+			},
+			_deletedName: { type: String }
 		};
 	}
 

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -273,6 +273,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		await organization.delete();
 
 		this._items = this._items.filter(cur => cur.organization !== organization);
+		this._deletedName = organization.name();
 
 		this.shadowRoot.querySelector('#delete-succeeded-toast').open = true;
 	}
@@ -374,8 +375,8 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				<d2l-button slot="footer" primary dialog-action="yes">${this.localize('yesAction')}</d2l-button>
 				<d2l-button slot="footer" dialog-action>${this.localize('noAction')}</d2l-button>
 			</d2l-dialog-confirm>
-			<d2l-alert-toast id="delete-succeeded-toast" type="default" announce-text=${this.localize('deleteSucceeded')}>
-				${this.localize('deleteSucceeded')}
+			<d2l-alert-toast id="delete-succeeded-toast" type="default" announce-text=${this.localize('deleteSucceeded', 'name', this._deletedName)}>
+				${this.localize('deleteSucceeded', 'name', this._deletedName)}
 			</d2l-alert-toast>
 		`;
 	}

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -5,7 +5,7 @@ export default {
 	"confirmDeleteTitle": "Confirm Delete", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
 	"defaultLearningPathName": "Untitled Learning Path", // Default name given to a newly created Learning Path
-	"deleteSucceeded": "Deleted Successfully", // The toast message displayed when a Learning Path is successfully deleted
+	"deleteSucceeded": "{name} was removed successfully.", // The toast message displayed when a Learning Path is successfully deleted
 	"noAction": "Cancel", // The 'No' button action text in the delete Learning Path confirmation dialog
 	"noLearningPath": "There are no learning paths to display", // A page that lists learning paths this shows up when there are none to list.
 	"noLearningPathWithSearchTerm": "0 search results found for \"{searchTerm}\"", // After searching for learning paths this shows up when there are no search results.


### PR DESCRIPTION
[DE37552](https://rally1.rallydev.com/#/detail/defect/363051082516?fdp=true)

Changed language in toast to "{LP name} was removed successfully."