### PR TITLE
Delete learning path button is now accessible

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -414,7 +414,12 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 							${item.organization.name()}
 						</d2l-list-item-content>
 						<div slot="actions">
-							${ item.remove ? html`<d2l-button-icon icon="tier1:delete" @click="${item.remove}"></d2l-button-icon>` : null }
+							${ item.remove ? html`
+							<d2l-button-icon
+								text="${this.localize('removeLearningPath', 'name', item.organization.name())}"
+								icon="tier1:delete"
+								@click="${item.remove}">
+							</d2l-button-icon>` : null }
 						</div>
 					</d2l-list-item>
 				`

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -12,6 +12,7 @@ export default {
 	"pageNext": "To next page", // Label for the next page button
 	"pagePrevious": "To previous page", // Label for the back to previous page button
 	"pageSelection": "On page {pageCurrent} of {pageTotal}. Enter a page number to go to that page", // Label for the page number input that lists the current page and lets the user jump to specific pages
+	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
 	"search": "Search", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Search...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Delete Learning Path" // The 'Yes' button action text in the delete Learning Path confirmation dialog


### PR DESCRIPTION
[DE37492](https://rally1.rallydev.com/#/detail/defect/362512928744?fdp=true)

Aria text added to delete button. Text while reading with a screen reader matches the label for deleting activities and includes title: "Remove learning path, {name}. Button"