### PR TITLE
Added visibility status to admin list page

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -411,7 +411,11 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 							</d2l-organization-image>
 						</div>
 						<d2l-list-item-content>
-							${item.organization.name()}
+							<div>${item.organization.name()}</div>
+							<div slot="secondary">
+								<d2l-icon icon="tier1:visibility-${item.organization.isActive() ? 'show' : 'hide'}"></d2l-icon>
+								${item.organization.isActive() ? 'Visible' : 'Hidden'} to users
+							</div>
 						</d2l-list-item-content>
 						<div slot="actions">
 							${ item.remove ? html`<d2l-button-icon icon="tier1:delete" @click="${item.remove}"></d2l-button-icon>` : null }

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -414,7 +414,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 							<div>${item.organization.name()}</div>
 							<div slot="secondary">
 								<d2l-icon icon="tier1:visibility-${item.organization.isActive() ? 'show' : 'hide'}"></d2l-icon>
-								${item.organization.isActive() ? 'Visible' : 'Hidden'} to users
+								${item.organization.isActive() ? this.localize('visibleToUsers') : this.localize('hiddenFromUsers')}
 							</div>
 						</d2l-list-item-content>
 						<div slot="actions">

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -6,6 +6,7 @@ export default {
 	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
 	"defaultLearningPathName": "Untitled Learning Path", // Default name given to a newly created Learning Path
 	"deleteSucceeded": "Deleted Successfully", // The toast message displayed when a Learning Path is successfully deleted
+	"hiddenFromUsers": "Hidden from users", // Visibility status displayed when a learning path is not visible
 	"noAction": "Cancel", // The 'No' button action text in the delete Learning Path confirmation dialog
 	"noLearningPath": "There are no learning paths to display", // A page that lists learning paths this shows up when there are none to list.
 	"noLearningPathWithSearchTerm": "0 search results found for \"{searchTerm}\"", // After searching for learning paths this shows up when there are no search results.
@@ -14,5 +15,6 @@ export default {
 	"pageSelection": "On page {pageCurrent} of {pageTotal}. Enter a page number to go to that page", // Label for the page number input that lists the current page and lets the user jump to specific pages
 	"search": "Search", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Search...", // Placeholder text for the search input to search the list of org units
+	"visibleToUsers": "Visible to users", // Visibility status displayed when a learning path is visible
 	"yesAction": "Delete Learning Path" // The 'Yes' button action text in the delete Learning Path confirmation dialog
 };

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -5,7 +5,7 @@ export default {
 	"confirmDeleteTitle": "Confirm Delete", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
 	"defaultLearningPathName": "Untitled Learning Path", // Default name given to a newly created Learning Path
-  "deleteSucceeded": "{name} was removed successfully.", // The toast message displayed when a Learning Path is successfully deleted
+	"deleteSucceeded": "{name} was removed successfully.", // The toast message displayed when a Learning Path is successfully deleted
 	"hiddenFromUsers": "Hidden from users", // Visibility status displayed when a learning path is not visible
 	"noAction": "Cancel", // The 'No' button action text in the delete Learning Path confirmation dialog
 	"noLearningPath": "There are no learning paths to display", // A page that lists learning paths this shows up when there are none to list.


### PR DESCRIPTION
[DE37521](https://rally1.rallydev.com/#/detail/defect/362781454568?fdp=true)

The added visibility status takes advantage of the list component's secondary slot, which is meant exactly for this sort of thing. 

<img width="668" alt="Screen Shot 2020-01-29 at 1 17 13 PM" src="https://user-images.githubusercontent.com/2412740/73384946-40560f00-429a-11ea-98c5-889e5da20394.png">