### PR TITLE
DE37585 dispose when loading new entities

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -249,6 +249,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			}
 		);
 		collection.subEntitiesLoaded().then(() => {
+			this._disposeOldEntities();
 			this._items = items;
 			this._totalPages = collection.totalPages();
 			this._currentPage = collection.currentPage();
@@ -261,6 +262,13 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			}
 			this._firstLoad = false;
 		});
+	}
+
+	_disposeOldEntities() {
+		for(var x = 0; x < this._items.length; x++) {
+			this._items[x] && dispose(this._items[x]);
+		}
+		this._collection && dispose(this._collection);
 	}
 
 	async _deleteItem(organization) {

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -265,9 +265,9 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	}
 
 	_disposeOldEntities() {
-		for(var x = 0; x < this._items.length; x++) {
-			this._items[x] && dispose(this._items[x]);
-		}
+		this._items && this._items.forEach(item => {
+			item && dispose(item);
+		});
 		this._collection && dispose(this._collection);
 	}
 


### PR DESCRIPTION
This pr resolves a defect where loading any item in the admin list twice or more will cause an error and prevent refreshing the page on deletion.

This error can be caused by searching and then deleting something on the first page (Initial load -> second load via search). It can also be caused by going to the first page, second page, back to the first page, and then deleting (initial load p1 -> initial load p2 -> second load p1).

These changes resolve the defect by disposing the items and collection entities before their references are lost to those of the search or the page change. This prevents them from posthumously firing the events that would throw an error.

