### PR TITLE
Remove include from style tag

### DIFF
--- a/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
+++ b/components/d2l-organization-consortium/d2l-organization-consortium-tabs.js
@@ -113,8 +113,7 @@ class OrganizationConsortiumTabs extends EntityMixin(OrganizationConsortiumLocal
 
 	static get template() {
 		return html`
-		<style include="d2l-typography-shared-styles">
-
+		<style>
 			.d2l-consortium-tab-box {
 				display: flex;
 				flex-wrap: nowrap;


### PR DESCRIPTION
This is not needed and is causing a console warning.