### PR TITLE
Update delete button to context menu

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -248,7 +248,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						actions: {
 							remove: organization.canDelete() ? () => this._deleteItem(organization) : null
 						},
-						hasActions: function() { return Object.values(this.actions).some((action) => action) }
+						hasActions: function() { return Object.values(this.actions).some((action) => action); }
 					};
 					loadedCount++;
 					if (loadedCount > totalCount) {

--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -2,13 +2,17 @@ import '../d2l-organization-image/d2l-organization-image.js';
 import './d2l-organization-admin-list-pager.js';
 import './d2l-organization-admin-list-search-header.js';
 import '@brightspace-ui/core/components/button/button.js';
-import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/list/list-item-content.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-more.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import 'd2l-alert/d2l-alert-toast.js';
 import {
 	heading1Styles,
@@ -241,7 +245,10 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 					items[index] = {
 						usage: { editHref: () => activityUsage.editHref() },
 						organization,
-						remove: organization.canDelete() ? () => this._deleteItem(organization) : null
+						actions: {
+							remove: organization.canDelete() ? () => this._deleteItem(organization) : null
+						},
+						hasActions: function() { return Object.values(this.actions).some((action) => action) }
 					};
 					loadedCount++;
 					if (loadedCount > totalCount) {
@@ -371,7 +378,9 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				<div class='d2l-organization-admin-list-background-gradient'></div>
 				<div class='d2l-organization-admin-list-content d2l-organization-admin-list-body'>
 					${search}
-					<div class="d2l-organization-admin-list-list" aria-live="polite" aria-busy="${!this._loaded ? html`true` : html`false`}">${items}</div>
+					<div class="d2l-organization-admin-list-list" aria-live="polite" aria-busy="${!this._loaded ? html`true` : html`false`}">
+						${items}
+					</div>
 					${this._handleLoading(() => this._items.length <= 0 ? null : html`
 						<d2l-organization-admin-list-pager
 							current-page="${this._currentPage}"
@@ -430,12 +439,21 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 							</div>
 						</d2l-list-item-content>
 						<div slot="actions">
-							${ item.remove ? html`
-							<d2l-button-icon
-								text="${this.localize('removeLearningPath', 'name', item.organization.name())}"
-								icon="tier1:delete"
-								@click="${item.remove}">
-							</d2l-button-icon>` : null }
+							${ item.hasActions() ? html`
+							<d2l-dropdown-more text="${this.localize('actions')}">
+								<d2l-dropdown-menu>
+									<d2l-menu label="${this.localize('actionsForLP', 'name', item.organization.name())}">
+										${item.actions.remove ? html`
+										<d2l-menu-item
+											text="${this.localize('removeLearningPath')}"
+											@click="${item.actions.remove}"
+										>
+										</d2l-menu-item>
+										` : null}
+									</d2l-menu>
+								</d2l-dropdown-menu>
+							</d2l-dropdown-more>
+							` : null }
 						</div>
 					</d2l-list-item>
 				`

--- a/components/d2l-organization-admin-list/lang/ar.js
+++ b/components/d2l-organization-admin-list/lang/ar.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "This item will be moved to the recycle bin and can be restored or permanently deleted later.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Confirm Delete", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "إنشاء مسار التعلّم", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "الانتقال إلى الصفحة التالية", // Label for the next page button
 	"pagePrevious": "الانتقال إلى الصفحة السابقة", // Label for the back to previous page button
 	"pageSelection": "في الصفحة {pageCurrent} من أصل {pageTotal}. إدخال رقم صفحة للانتقال إليها", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "بحث", // Label for the search input to search the list of org units
 	"searchPlaceholder": "البحث...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Delete Learning Path" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/de.js
+++ b/components/d2l-organization-admin-list/lang/de.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Dieses Element wird in den Papierkorb verschoben und kann wiederhergestellt oder endgültig gelöscht werden.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Löschen bestätigen", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Lernpfad erstellen", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "Zur nächsten Seite", // Label for the next page button
 	"pagePrevious": "Zur vorherigen Seite", // Label for the back to previous page button
 	"pageSelection": "Auf Seite {pageCurrent} von {pageTotal}. Geben Sie eine Seitenzahl ein, um zu dieser Seite zu gelangen", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Suchen", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Suchen...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Lernpfad löschen" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/en.js
+++ b/components/d2l-organization-admin-list/lang/en.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "This item will be moved to the recycle bin and can be restored or permanently deleted later.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Confirm Delete", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Create Learning Path", // Button to create a new Learning Path
@@ -13,7 +15,7 @@ export default {
 	"pageNext": "To next page", // Label for the next page button
 	"pagePrevious": "To previous page", // Label for the back to previous page button
 	"pageSelection": "On page {pageCurrent} of {pageTotal}. Enter a page number to go to that page", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Search", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Search...", // Placeholder text for the search input to search the list of org units
 	"visibleToUsers": "Visible to users", // Visibility status displayed when a learning path is visible

--- a/components/d2l-organization-admin-list/lang/es.js
+++ b/components/d2l-organization-admin-list/lang/es.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Se moverá este elemento a la papelera de reciclaje y se podrá restaurar o eliminar de forma permanente en otro momento.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Confirmar eliminación", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Crear plan de aprendizaje", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "A la siguiente página", // Label for the next page button
 	"pagePrevious": "A la página anterior", // Label for the back to previous page button
 	"pageSelection": "En la página {pageCurrent} de {pageTotal}. Ingrese un número de página para ir a ella", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Buscar", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Buscar…", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Eliminar plan de aprendizaje" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/fr.js
+++ b/components/d2l-organization-admin-list/lang/fr.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Cet élément sera déplacé dans la corbeille et il pourra être restauré ou supprimé définitivement plus tard.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Confirmer la suppression", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Créer un chemin d’apprentissage", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "À la page suivante", // Label for the next page button
 	"pagePrevious": "À la page précédente", // Label for the back to previous page button
 	"pageSelection": "À la page {pageCurrent} de {pageTotal}. Inscrivez un numéro de page pour accéder à celle-ci", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Rechercher", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Recherche…", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Supprimer le Chemin d’apprentissage" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/ja.js
+++ b/components/d2l-organization-admin-list/lang/ja.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "この項目はごみ箱に移動されます。後で復元することも完全に削除することも可能です。", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "削除の確認", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "学習パスの作成", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "次のページへ", // Label for the next page button
 	"pagePrevious": "前のページへ", // Label for the back to previous page button
 	"pageSelection": "{pageTotal} ページ中 {pageCurrent} ページ目ページ番号を入力して、そのページに移動", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "検索", // Label for the search input to search the list of org units
 	"searchPlaceholder": "検索...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "学習パスの削除" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/ko.js
+++ b/components/d2l-organization-admin-list/lang/ko.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "이 항목은 휴지통으로 이동되며 나중에 복원하거나 영구적으로 삭제할 수 있습니다.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "삭제 확인", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "학습 경로 생성", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "다음 페이지로 이동", // Label for the next page button
 	"pagePrevious": "이전 페이지로 이동", // Label for the back to previous page button
 	"pageSelection": "{pageCurrent} / {pageTotal} 페이지. 해당 페이지로 이동하려면 페이지 번호를 입력하십시오.", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "검색", // Label for the search input to search the list of org units
 	"searchPlaceholder": "검색...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "학습 경로를 삭제합니다." // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/nl.js
+++ b/components/d2l-organization-admin-list/lang/nl.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Dit item wordt verplaatst naar de prullenbak en kan later worden hersteld of permanent worden verwijderd.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Verwijderen bevestigen", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Leertraject maken", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "Naar volgende pagina", // Label for the next page button
 	"pagePrevious": "Naar vorige pagina", // Label for the back to previous page button
 	"pageSelection": "Op pagina {pageCurrent} van {pageTotal}. Voer een paginanummer in om naar die pagina te gaan", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Zoeken", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Zoeken...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Leertraject verwijderen" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/pt.js
+++ b/components/d2l-organization-admin-list/lang/pt.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Este item será movido para a lixeira, onde poderá ser restaurado ou permanentemente excluído mais tarde.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Confirmar Exclusão", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Criar Caminho de Aprendizagem", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "Para a próxima página", // Label for the next page button
 	"pagePrevious": "Para a página anterior", // Label for the back to previous page button
 	"pageSelection": "Na página {pageCurrent} de {pageTotal}. Insira o número de uma página para acessá-la", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Pesquisar", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Pesquisar...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Editar Caminho de Aprendizagem" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/sv.js
+++ b/components/d2l-organization-admin-list/lang/sv.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Det här objektet flyttas till papperskorgen och kan återställas eller tas bort permanent senare.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Bekräfta borttagning", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Skapa inlärningsväg", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "Till nästa sida", // Label for the next page button
 	"pagePrevious": "Till föregående sida", // Label for the back to previous page button
 	"pageSelection": "På sidan {pageCurrent} av {pageTotal}. Ange ett sidnummer för att gå till den sidan", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Sökning", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Sök ...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Ta bort inlärningsväg" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/tr.js
+++ b/components/d2l-organization-admin-list/lang/tr.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "Bu öğe geri dönüşüm kutusuna taşınır ve yeniden yüklenebilir veya daha sonra kalıcı olarak silinebilir.", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "Silme İşlemini Onayla", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "Öğrenme Yolu Oluştur", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "Sonraki sayfaya git", // Label for the next page button
 	"pagePrevious": "Önceki sayfaya git", // Label for the back to previous page button
 	"pageSelection": "{pageCurrent}/{pageTotal} numaralı sayfada. İlgili sayfaya gitmek için bir sayfa numarası seçin", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "Ara", // Label for the search input to search the list of org units
 	"searchPlaceholder": "Ara...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "Öğrenme Yolunu Sil" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/zh-tw.js
+++ b/components/d2l-organization-admin-list/lang/zh-tw.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "此項目將被移至資源回收桶，並可還原或在日後永久刪除。", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "確認刪除", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "建立學習路徑", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "前往下一頁", // Label for the next page button
 	"pagePrevious": "前往上一頁", // Label for the back to previous page button
 	"pageSelection": "在第 {pageCurrent} 頁，共 {pageTotal} 頁。請輸入頁面號碼以前往該頁面", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "搜尋", // Label for the search input to search the list of org units
 	"searchPlaceholder": "搜尋...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "刪除學習路徑" // The 'Yes' button action text in the delete Learning Path confirmation dialog

--- a/components/d2l-organization-admin-list/lang/zh.js
+++ b/components/d2l-organization-admin-list/lang/zh.js
@@ -1,6 +1,8 @@
 /* eslint quotes: 0 */
 
 export default {
+	"actions": "Actions", // Label for learning path context menu
+	"actionsForLP": "Actions for {name}", // Label for within the context menu
 	"confirmDeleteMessage": "此项目移至回收站后可进行恢复或稍后永久删除。", // The message for the delete Learning Path confirmation dialog
 	"confirmDeleteTitle": "确认删除", // The title for the delete Learning Path confirmation dialog
 	"createLearningPath": "创建学习路径", // Button to create a new Learning Path
@@ -12,7 +14,7 @@ export default {
 	"pageNext": "至下一页", // Label for the next page button
 	"pagePrevious": "至上一页", // Label for the back to previous page button
 	"pageSelection": "在第 {pageCurrent}/{pageTotal} 页。输入页码以转到该页", // Label for the page number input that lists the current page and lets the user jump to specific pages
-	"removeLearningPath": "Remove learning path, {name}.", // Label for delete learning path button
+	"removeLearningPath": "Delete", // Label for delete learning path button
 	"search": "搜索", // Label for the search input to search the list of org units
 	"searchPlaceholder": "搜索...", // Placeholder text for the search input to search the list of org units
 	"yesAction": "删除学习路径" // The 'Yes' button action text in the delete Learning Path confirmation dialog


### PR DESCRIPTION
**Context**
[DE38052](https://rally1.rallydev.com/#/detail/defect/372792424408?fdp=true)

This changes the trashcan delete button to a context menu that includes any actions for the learning path list item in the admin list page. A new property called `actions` has been created to house all action handlers; this makes room for expansion of this menu later.

The context menu is based off of a similar menu found in the My Courses widget and leverages `@brightspace-ui/core/dropdown/dropdown-more`.
<img width="827" alt="Screen Shot 2020-03-19 at 1 04 33 PM" src="https://user-images.githubusercontent.com/2412740/77097072-9ae03180-69e6-11ea-8e6b-55d5b68a456b.png">

**Quality**
* Tested with demo page
* Tested with local instance of BSI