### PR TITLE
Changing click event to the d2l-menu-item-select event to handle keyb…

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -446,7 +446,7 @@ class AdminList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 										${item.actions.remove ? html`
 										<d2l-menu-item
 											text="${this.localize('removeLearningPath')}"
-											@click="${item.actions.remove}"
+											@d2l-menu-item-select="${item.actions.remove}"
 										>
 										</d2l-menu-item>
 										` : null}


### PR DESCRIPTION
**Context**
Fixes a keyboard mode bug that prevented the user from selecting the delete item while using a keyboard.