### PR TITLE
Adding styles to prevent inactive courses from appearing clickable

### DIFF
--- a/components/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/components/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -174,6 +174,10 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 					position: relative;
 					width: 220px;
 				}
+				.dedc-base-container:not([has-link]) .dedc-image {
+					filter: grayscale(1);
+					opacity: 0.5;
+				}
 				.dedc-image-pulse {
 					animation: loadingPulse 1.8s linear infinite;
 					background-color: var(--d2l-color-sylvite);
@@ -246,9 +250,11 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 					background-color: var(--d2l-color-sylvite);
 					border-radius: 4px;
 				}
+				.dedc-base-container[has-link] .dedc-title {
+					color: var(--d2l-color-celestine);
+				}
 				.dedc-title {
 					@apply --d2l-body-standard-text;
-					color: var(--d2l-color-celestine);
 					letter-spacing: 0.4px;
 					line-height: 1;
 					margin: 0 0 0.1rem 0;


### PR DESCRIPTION
**Context**
[DE37652](https://rally1.rallydev.com/#/detail/defect/365729624044?fdp=true)

A similar change was pushed to the `enrollments` components. Makes inactive courses or those without a 'has-link' attribute appear greyed out.

![Screen Shot 2020-03-25 at 2 18 46 PM](https://user-images.githubusercontent.com/2412740/77571544-eb063a80-6ea3-11ea-9a59-33c49a0de254.png)

**Quality**
* Tested with demo page
* Tested with a local instance of BSI
* Tested with a local LE instance