### PR TITLE
handle null organization in d2l-organization-image _onOrganizationChange

### DIFF
--- a/components/d2l-organization-image/d2l-organization-image.js
+++ b/components/d2l-organization-image/d2l-organization-image.js
@@ -155,6 +155,10 @@ class D2lOrganizationImage extends EntityMixin(PolymerElement) {
 	}
 
 	_onOrganizationChange(organization) {
+		if (organization === null) {
+			return; // invoked for removed organization
+		}
+
 		if (organization.hasClass(organizationClasses.courseOffering)) {
 			this._entity.onImageChange((image) => {
 				this._primaryImage = image.entity();


### PR DESCRIPTION
Problem to be fixed:
   When Learning Path organization unit is deleted in Learning Paths admin page, the _onOrganizationChange handler in d2l-organization-image is throwing exception.