### PR TITLE
added title for link and hide text for voice over

### DIFF
--- a/components/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/components/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -376,8 +376,8 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 			</style>
 			<d2l-resize-aware class="dedc-container" mobile$="[[_mobile]]" show-text$=[[_forceShowText]]>
 				<div class="dedc-base-container" has-link$="[[_organizationHomepageUrl]]">
-					<a class="d2l-focusable" href$="[[_organizationHomepageUrl]]">
-						<span class="dedc-link-text">[[_title]]</span>
+					<a class="d2l-focusable" title="[[_title]]" href$="[[_organizationHomepageUrl]]">
+						<span class="dedc-link-text" aria-hidden="true">[[_title]]</span>
 					</a>
 					<div class="dedc-image" show-image$=[[_forceShowImage]]>
 						<div class="dedc-image-pulse"></div>

--- a/components/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/components/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -376,7 +376,7 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 			</style>
 			<d2l-resize-aware class="dedc-container" mobile$="[[_mobile]]" show-text$=[[_forceShowText]]>
 				<div class="dedc-base-container" has-link$="[[_organizationHomepageUrl]]">
-					<a class="d2l-focusable" title="[[_title]]" href$="[[_organizationHomepageUrl]]">
+					<a class="d2l-focusable" title$="[[_title]]" href$="[[_organizationHomepageUrl]]">
 						<span class="dedc-link-text" aria-hidden="true">[[_title]]</span>
 					</a>
 					<div class="dedc-image" show-image$=[[_forceShowImage]]>


### PR DESCRIPTION
## Fix
While using Voiceover + Safari, course links are read out as "Course 3, text element". These should be read out as links instead to avoid confusion.

[DE37662](https://rally1.rallydev.com/#/357252966636d/detail/defect/366052133056?fdp=true)