### PR TITLE
add right padding so circle meter wont cut off

### DIFF
--- a/components/d2l-organization-detail-card/d2l-organization-detail-card.js
+++ b/components/d2l-organization-detail-card/d2l-organization-detail-card.js
@@ -275,6 +275,7 @@ class D2lOrganizationDetailCard extends mixinBehaviors([
 					top: -1.2rem;
 					right: -1.2rem;
 					z-index: 100;
+					padding-right:5px;
 				}
 				:host(:dir(rtl)) .dedc-module-completion-meter {
 					left: -1.2rem;


### PR DESCRIPTION
[DE37645](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?qdp=%2Fdetail%2Fdefect%2F365681597704)

If you shrink the browser window horizontally to its smallest breakpoint, the module completion circles will end up being cut off.  

Before
<img width="484" alt="Screen Shot 2020-04-15 at 14 16 34" src="https://user-images.githubusercontent.com/4850036/79372468-e0c7e100-7f23-11ea-9efc-36775715dacd.png">

After
<img width="491" alt="Screen Shot 2020-04-15 at 14 17 02" src="https://user-images.githubusercontent.com/4850036/79372518-e6252b80-7f23-11ea-9c52-08a621ef3f5f.png">
