### PR TITLE
DE38903 - Remove unused event and its tests from d2l-organization-date

### DIFF
--- a/components/d2l-organization-date/d2l-organization-date.js
+++ b/components/d2l-organization-date/d2l-organization-date.js
@@ -34,8 +34,7 @@ class OrganizationDate extends mixinBehaviors([
 			_statusText: {
 				type: String,
 				value: null
-			},
-			_entityStatus: String
+			}
 		};
 	}
 
@@ -63,7 +62,6 @@ class OrganizationDate extends mixinBehaviors([
 			return;
 		}
 
-		this._entityStatus = organization.isActive();
 		this._setOrganizationDate(this.hideCourseStartDate, this.hideCourseEndDate);
 	}
 
@@ -78,14 +76,6 @@ class OrganizationDate extends mixinBehaviors([
 			'date', this.formatDate(date.date, {format: 'MMMM d, yyyy'}),
 			'time', this.formatTime(date.date)
 		);
-
-		if (this._statusText || (this._entityStatus !== undefined)) {
-			this.fire('d2l-organization-date', {
-				active: !!this._entityStatus,
-				beforeStartDate: date.beforeStartDate,
-				afterEndDate: date.afterEndDate
-			});
-		}
 	}
 
 	_sendVoiceReaderInfo(statusText) {

--- a/test/d2l-organization-date/d2l-organization-date.js
+++ b/test/d2l-organization-date/d2l-organization-date.js
@@ -150,48 +150,6 @@ describe('d2l-organization-date', () => {
 			component = await fixture('org-date');
 		});
 
-		it('should send event with detail of inactive as true', done => {
-			component.addEventListener('d2l-organization-date', function(e) {
-				expect(e.detail.active).to.be.true;
-				done();
-			});
-
-			processedDateStub.returns({
-				type: 'startsAt',
-				date: date
-			});
-			isActiveStub.returns(true);
-			component._entity = organizationEntity;
-		});
-
-		it('should send event with detail of beforeStartDate as true.', done => {
-			component.addEventListener('d2l-organization-date', function(e) {
-				expect(e.detail.beforeStartDate).to.be.true;
-				done();
-			});
-
-			processedDateStub.returns({
-				type: 'startsAt',
-				date: date,
-				beforeStartDate: true
-			});
-			component._entity = organizationEntity;
-		});
-
-		it('should send event with detail of afterEndDate as true.', done => {
-			component.addEventListener('d2l-organization-date', function(e) {
-				expect(e.detail.afterEndDate).to.be.true;
-				done();
-			});
-
-			processedDateStub.returns({
-				type: 'startsAt',
-				date: date,
-				afterEndDate: true
-			});
-			component._entity = organizationEntity;
-		});
-
 		it('should send the "Starts" text when date type is startsAt', done => {
 			component.addEventListener('d2l-organization-accessible', function(e) {
 				expect(e.detail.organization.date).to.contain('Starts ');


### PR DESCRIPTION
Related to https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/184, I'm migrating usages of the `processedDate` function from `OrganizationEntity` to no longer access `beforeStartDate` and `afterEndDate` directly, and to instead use the new functions.  In this case however, it's only used in sending an event that is not consumed by anything.  So just removing the event here.

I expect this was used before moving to the `siren-sdk`, which allows consumers of this component to get the info easily themselves instead of through this event. 