### PR TITLE
Updating lang term to match assignments and update widget

### DIFF
--- a/components/d2l-organization-updates/build/lang/en.js
+++ b/components/d2l-organization-updates/build/lang/en.js
@@ -11,7 +11,7 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'unattemptedQuizzes': '{number} Unattempted Quizzes',
 			'ungradedQuizzes': '{number} Ungraded Quizzes',
 			'unreadAssignmentFeedback': '{number} Unread Assignment Feedback',
-			'unreadAssignmentSubmissions': '{number} Unread Assignment Submission Files',
+			'unreadAssignmentSubmissions': '{number} New Assignment Submissions',
 			'unreadDiscussionFeedback': '{number} Unread Discussion Feedback',
 			'unreadDiscussions': '{number} Unread Discussions',
 			'unreadQuizzesFeedback': '{number} Unread Quizzes Feedback',

--- a/components/d2l-organization-updates/lang/en.json
+++ b/components/d2l-organization-updates/lang/en.json
@@ -16,8 +16,8 @@
     "context": "The amount of feedback comments that a user has not read about assignments"
   },
   "unreadAssignmentSubmissions": {
-    "translation": "{number} Unread Assignment Submission Files",
-    "context": "The number of assignment files that still need to be read."
+    "translation": "{number} New Assignment Submissions",
+    "context": "The number of assignment submissions that still need to be read."
   },
   "unreadDiscussionFeedback": {
     "translation": "{number} Unread Discussion Feedback",


### PR DESCRIPTION
This brings the my courses widget in line with what the updates widget and the assignments tool have. As well as the the my courses widget options.