### PR TITLE
d2l-organization-image add a skeleton while loading

### DIFF
--- a/components/d2l-organization-image/d2l-organization-image.js
+++ b/components/d2l-organization-image/d2l-organization-image.js
@@ -34,13 +34,21 @@ class D2lOrganizationImage extends EntityMixin(PolymerElement) {
 				type: String,
 				value: 'tile'
 			},
+			skeleton: {
+				type: Boolean,
+				value: false
+			},
 			_primaryImage: String,
 			_secondaryImage: String,
 			_tertiaryImage: String,
 			_noImage: {
 				type: Boolean,
 				value: false
-			}
+			},
+			_showImage: {
+				type: Boolean,
+				value: false
+			},
 		};
 	}
 
@@ -119,11 +127,20 @@ class D2lOrganizationImage extends EntityMixin(PolymerElement) {
 					stroke-dasharray: 0.25rem;
 					stroke-dashoffset: 0.125rem;
 				}
+				.d2l-organization-image-skeleton-rect {
+					animation: loadingPulse 1.8s linear infinite;
+					fill: var(--d2l-color-sylvite);
+				}
 			</style>
 			<template is="dom-if" if="[[_noImage]]">
 				<svg class="doi-no-image">
 					<rect x="0" y="0" width="100%" height="100%"></rect>
 				</svg>
+			</template>
+			<template is="dom-if" if="[[skeleton]]" >
+			<svg viewBox="0 0 216 120" width="100%" slot="illustration" hidden$=[[_noImage]]>
+				<rect x="0" width="100%" y="0" height="100%" stroke="none" class="d2l-organization-image-skeleton-rect"></rect>
+			</svg>
 			</template>
 			<d2l-course-image image="[[_primaryImage]]" sizes="[[tileSizes]]" type="[[type]]" hidden$=[[_noImage]]></d2l-course-image>
 			<div class="doi-flex" hidden$=[[_noImage]]>
@@ -170,6 +187,8 @@ class D2lOrganizationImage extends EntityMixin(PolymerElement) {
 		}
 
 		organization.subEntitiesLoaded().then(() => {
+			this.skeleton = false;
+
 			if (!this._primaryImage) {
 				this._noImage = true;
 				this._imageLoaded();

--- a/demo/d2l-organization-image/d2l-organization-image-demo.html
+++ b/demo/d2l-organization-image/d2l-organization-image-demo.html
@@ -69,6 +69,14 @@
 					</div>
 				</template>
 			</demo-snippet>
+			<h3>Learning Path d2l-organization-image skeleton on demo</h3>
+			<demo-snippet>
+				<template>
+					<div class="demo">
+						<d2l-organization-image href="../data/learningPath/organization-learning-path.json" token="whatever" skeleton></d2l-organization-image>
+					</div>
+				</template>
+			</demo-snippet>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
[Rally](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?qdp=%2Fdetail%2Fuserstory%2F384013536908)

## loading demo
<img width="1518" alt="Screen Shot 2020-05-24 at 15 57 28" src="https://user-images.githubusercontent.com/4850036/82763688-741fec00-9dd7-11ea-9b0a-765e402094fc.png">
