### PR TITLE
Bump sequences to major version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-resize-aware": "BrightspaceUI/resize-aware#semver:^1",
-    "d2l-sequences": "BrightspaceHypermediaComponents/sequences#semver:^1",
+    "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
     "d2l-resize-aware": "BrightspaceUI/resize-aware#semver:^1",
-    "d2l-sequences": "github:BrightspaceHypermediaComponents/sequences#semver:^2",
+    "d2l-sequences": "BrightspaceHypermediaComponents/sequences#semver:^2",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1",


### PR DESCRIPTION
The Phoenix team has released a new major version of `sequences` and we broke CI by bumping it in BSI without bumping it here or in `enrollments`. I double-checked that there were no breaking changes for `organizations` or `enrollments` BUT please feel free to double-check the diff for the `v2.0.1` release commit, or later releases.

https://github.com/BrightspaceHypermediaComponents/sequences/commit/40c2bc481acf70b32007466e7fdf08954284b0be