### PR TITLE
removing IE11 polyfills

### DIFF
--- a/demo/d2l-organization-admin-list/d2l-organization-admin-list.html
+++ b/demo/d2l-organization-admin-list/d2l-organization-admin-list.html
@@ -7,10 +7,6 @@
 		<title>d2l-organization-admin-list demo</title>
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-		<!-- For IE11 -->
-		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
-
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';

--- a/demo/d2l-organization-availability-set/d2l-organization-availability-set.html
+++ b/demo/d2l-organization-availability-set/d2l-organization-availability-set.html
@@ -7,10 +7,6 @@
 		<title>d2l-organization-availability-set demo</title>
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-		<!-- For IE11 -->
-		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
-
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';

--- a/demo/d2l-organization-consortium/d2l-organization-consortium.html
+++ b/demo/d2l-organization-consortium/d2l-organization-consortium.html
@@ -7,11 +7,6 @@
 		<title>d2l-organization-consortium demo</title>
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-		<!-- For IE11 -->
-		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../node_modules/@ungap/url-search-params/min.js"></script>
-		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
-
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';

--- a/demo/d2l-organization-detail-card/d2l-organization-detail-card-demo.html
+++ b/demo/d2l-organization-detail-card/d2l-organization-detail-card-demo.html
@@ -7,10 +7,6 @@
 		<title>d2l-organization-detail-card demo</title>
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-		<!-- For IE11 -->
-		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
-
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';

--- a/demo/d2l-organization-image/d2l-organization-image-demo.html
+++ b/demo/d2l-organization-image/d2l-organization-image-demo.html
@@ -7,10 +7,6 @@
 		<title>d2l-organization-image demo</title>
 		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 
-		<!-- For IE11 -->
-		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
-
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
 			import '@polymer/iron-demo-helpers/demo-snippet';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@polymer/iron-component-page": "^4.0.0",
     "@polymer/iron-demo-helpers": "^3.0.0",
     "@polymer/iron-test-helpers": "^3.0.0",
-    "@ungap/url-search-params": "^0.1.2",
     "@webcomponents/webcomponentsjs": "^2.2.6",
     "axe-core": "^3.4.0",
     "babel-eslint": "^10.0.1",
@@ -70,10 +69,8 @@
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "fastdom": "^1",
-    "lie": "^3.3.0",
     "lit-element": "^2.2.1",
     "siren-parser": "^8.0.0",
-    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1",
-    "whatwg-fetch": "^3.0.0"
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   }
 }


### PR DESCRIPTION
Not needed anymore! Also because some of these we not `devDependencies`, it was forcing BSI to install them.