### PR TITLE
DE40642 - Clear start date, end date, and semester info accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ To lint AND run local unit tests:
 npm run test
 ```
 
+To debug tests locally, run the command below and then navigate to `http://localhost:9876/debug.html`:
+```shell
+npm run test:headless:watch
+```
+
 ## Versioning, Releasing & Deploying
 
 By default, when a pull request is merged the patch version in the `package.json` will be incremented, a tag will be created, and a Github release will be created.

--- a/components/d2l-organization-date/d2l-organization-date.js
+++ b/components/d2l-organization-date/d2l-organization-date.js
@@ -67,11 +67,7 @@ class OrganizationDate extends mixinBehaviors([
 
 	_setOrganizationDate(hideCourseStartDate, hideCourseEndDate) {
 		var date = this._entity && this._entity.processedDate(hideCourseStartDate, hideCourseEndDate);
-		if (!date) {
-			return;
-		}
-
-		this._statusText = this.localize(
+		this._statusText = !date ? null : this.localize(
 			date.type,
 			'date', this.formatDate(date.date, {format: 'MMMM d, yyyy'}),
 			'time', this.formatTime(date.date)

--- a/components/d2l-organization-info/d2l-organization-info.js
+++ b/components/d2l-organization-info/d2l-organization-info.js
@@ -88,6 +88,8 @@ class OrganizationInfo extends mixinBehaviors([
 	}
 
 	_setSemesterName(showSemesterName) {
+		this._semesterName = null;
+
 		if (showSemesterName && this._entity) {
 			this._entity.onSemesterChange((semester) => {
 				this._semesterName = semester.name();

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:wc": "polymer lint",
     "start": "es-dev-server --node-resolve --dedupe --watch --open",
     "test:headless": "karma start",
+    "test:headless:watch": "karma start --auto-watch=true --single-run=false",
     "test:sauce": "karma start karma.sauce.conf.js"
   },
   "author": "D2L Corporation",

--- a/test/d2l-organization-date/d2l-organization-date.js
+++ b/test/d2l-organization-date/d2l-organization-date.js
@@ -150,6 +150,13 @@ describe('d2l-organization-date', () => {
 					done();
 				});
 			});
+
+			it ('should clear _statusText if the new org does not have a date', () => {
+				component._statusText = 'Old org date info';
+				component._entity = organizationEntity;
+
+				expect(component._statusText).to.be.null;
+			});
 		});
 
 		describe('Events', () => {

--- a/test/d2l-organization-info/d2l-organization-info.js
+++ b/test/d2l-organization-info/d2l-organization-info.js
@@ -50,7 +50,7 @@ describe('d2l-organization-info', () => {
 		it('should not set _semesterName when showSemesterName is false', () => {
 			component._entity = organizationEntity;
 			expect(onSemesterChangeStub).to.have.not.been.called;
-			expect(component._semesterName).to.equal(undefined);
+			expect(component._semesterName).to.equal(null);
 		});
 
 		it('should set _semesterName when showSemesterName is true', () => {
@@ -59,6 +59,34 @@ describe('d2l-organization-info', () => {
 
 			expect(onSemesterChangeStub).to.have.been.calledOnce;
 			expect(component._semesterName).to.equal(semesterEntity.name());
+		});
+
+		it('should reset _semesterName in case showSemesterName changes', () => {
+			component._entity = organizationEntity;
+			component.showSemesterName = true;
+
+			expect(component._semesterName).to.equal(semesterEntity.name());
+
+			component.showSemesterName = false;
+
+			expect(component._semesterName).to.be.null;
+			expect(onSemesterChangeStub).to.have.been.calledOnce;
+		});
+
+		it('should reset _semesterName in case the new org does not have a semester', () => {
+			component._entity = organizationEntity;
+			component.showSemesterName = true;
+
+			expect(component._semesterName).to.equal(semesterEntity.name());
+
+			component._entity = {
+				name: () => 'New Org Name',
+				code: () => 'NEW100',
+				onSemesterChange: () => {}
+			};
+
+			expect(component._semesterName).to.be.null;
+			expect(onSemesterChangeStub).to.have.been.calledOnce;
 		});
 	});
 


### PR DESCRIPTION
When re-ordering cards in My Courses, DOM nodes are being reused and these values are not being cleared if a card is moving into the place of one that _did_ have a semester or date info, but it _doesn't_.