### PR TITLE
feat: createOrgUnit to use create-form link if provided

### DIFF
--- a/components/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/components/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -360,7 +360,12 @@ class AdminList extends EntityMixinLit(LocalizeOrganizationAdminList(LitElement)
 			.createOrgUnit(name, 'LP', this.createActionType)
 			.then(organization => {
 				organization.onActivityUsageChange(activityUsage => {
-					window.location.href = activityUsage.editHref();
+					if (activityUsage.createFormHref()) {
+						window.location.href = activityUsage.createFormHref();
+					} else {
+						window.location.href = activityUsage.editHref();
+					}
+
 				});
 			});
 	}

--- a/test/d2l-organization-admin-list/d2l-organization-admin-list.js
+++ b/test/d2l-organization-admin-list/d2l-organization-admin-list.js
@@ -6,6 +6,7 @@ describe('d2l-organization-admin-list', () => {
 	let el;
 	let collectionEntity;
 	const basic = html`<d2l-organization-admin-list titleText="Learning Paths"></d2l-organization-admin-list>`;
+	const createLPElement = html`<d2l-organization-admin-list titleText="Learning Paths" createactiontype="7" href="/createLP"></d2l-organization-admin-list>`;
 
 	describe('accessibility', () => {
 		it('should pass all axe tests', async() => {
@@ -37,6 +38,17 @@ describe('d2l-organization-admin-list', () => {
 		collectionEntity.subEntitiesLoaded().then(() => {
 			expect(el._items).to.be.empty;
 			done();
+		});
+	});
+
+	describe('create learning path routing', () => {
+
+		it('should use create-form link when provided', async() => {
+			el = await fixture(createLPElement);
+		});
+
+		it('should use edit link when provided', async() => {
+			el = await fixture(createLPElement);
 		});
 	});
 });


### PR DESCRIPTION
US122312
https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F455165215100

```context```
The create LP button needs to be able to redirect to the create-form link if its provided, otherwise continue to use the edit link.

```quality```
still todo: unit tests