### PR TITLE
fix: make es-dev-server a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel-eslint": "^10.0.1",
     "deepmerge": "^4.2.2",
     "del": "^3.0.0",
+    "es-dev-server": "^1.57.3",
     "eslint": "^4.2.0",
     "eslint-config-brightspace": "^0.6.3",
     "eslint-plugin-html": "^4.0.1",
@@ -71,7 +72,6 @@
     "d2l-sequences": "BrightspaceHypermediaComponents/sequences#semver:^2",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "es-dev-server": "^1.57.3",
     "fastdom": "^1",
     "lit-element": "^2.2.1",
     "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"


### PR DESCRIPTION
So that libraries which depend on this one don't need to install it.