### PR TITLE
Fix: Eslint to ignore lang files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ bower_components-1.x
 *.ejs
 test/acceptance/*
 reports
+components/*/lang/*


### PR DESCRIPTION
We need the translation PRs for fr-on but they are failing due to eslint errors. 

Updating eslintignore to ignore lang files