### PR TITLE
Remove BSI reminder from PR template

### DIFF
--- a/components/.github/pull_request_template.md
+++ b/components/.github/pull_request_template.md
@@ -5,6 +5,3 @@
 [Replace with how your PR was tested - include automated tests, manual tests, testing environments, etc.]
 
 [For more details see: https://desire2learn.atlassian.net/wiki/spaces/AUR/pages/667844887/PR+Review+and+Template]
-
-##Reminder
-Please remember to update BSI for this repo after brightspace-bot releases a new version.


### PR DESCRIPTION
So I ran across this and figured I'd clean it up (this was added a few weeks before I wrote all the auto-BSI stuff).  But the template doesn't seem to be working at all from my quick test... @AKobets @zinabat have you seen this work or should the whole file just be deleted?  I can't ask Cheick 😢 